### PR TITLE
extend decennial route with “Downloadable”

### DIFF
--- a/app/routes/profile/census.js
+++ b/app/routes/profile/census.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import nestProfile from '../../utils/nest-profile';
+import Downloadable from '../../mixins/downloadable';
 
-export default Route.extend({
+
+export default Route.extend(Downloadable, {
   selection: service(),
 
   beforeModel() {
@@ -28,8 +29,6 @@ export default Route.extend({
       .query('row', { selectionId, type: 'decennial', comparator })
       .then(rows => rows.toArray());
 
-    const nestedModel = nestProfile(profileData, 'year', 'variable');
-
-    return nestedModel;
+    return profileData;
   }).enqueue().cancelOn('deactivate'),
 });


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR makes the Download Data button on decennial profiles work as expected (it was not working before)

- Routes with download buttons are extended with a mixin called Downloadable... this modified the profiles data and produces an array that is suitable for conversion to CSV.  Decennial was not using this mixin, so the data that the download button expected was never being produced.

Closes #589
