### PR TITLE
fix the census tab's section dropdown items

### DIFF
--- a/app/components/tab-dropdown.js
+++ b/app/components/tab-dropdown.js
@@ -9,6 +9,19 @@ export default Component.extend({
 
   dropdown: '',
 
+  censusItems: [
+    { anchor: '#sex-and-age', title: 'Age and Sex' },
+    { anchor: '#mutually-exclusive-race-hispanic-origin', title: 'Mutually Exclusive Race / Hispanic Origin' },
+    { anchor: '#hispanic-subgroup', title: 'Hispanic Subgroup' },
+    { anchor: '#asian-subgroup', title: 'Asian Subgroup' },
+    { anchor: '#relationship-to-head-of-household', title: 'Relationship to Head of Household' },
+    { anchor: '#household-type', title: 'Household Type' },
+    { anchor: '#housing-occupancy', title: 'Housing Occupancy' },
+    { anchor: '#housing-tenure', title: 'Housing Tenure' },
+    { anchor: '#tenure-by-age-of-householder', title: 'Tenure by Age of Househodler' },
+    { anchor: '#household-size', title: 'Household Size' },
+  ],
+
   demographicItems: [
     { anchor: '#sex-and-age', title: 'Age and Sex' },
     { anchor: '#mutually-exclusive-race-hispanic-origin', title: 'Mutually Exclusive Race / Hispanic Origin' },
@@ -63,6 +76,7 @@ export default Component.extend({
 
   @computed('dropdown')
   dropdownItems() {
+    const censusItems = this.get('censusItems');
     const demographicItems = this.get('demographicItems');
     const socialItems = this.get('socialItems');
     const economicItems = this.get('economicItems');
@@ -70,6 +84,9 @@ export default Component.extend({
 
     const dropdown = this.get('dropdown');
 
+    if (dropdown === 'census') {
+      return censusItems;
+    }
     if (dropdown === 'demographic') {
       return demographicItems;
     }

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -10,41 +10,7 @@
         </li>
         <li>
           {{#if (eq tab 'profile.census')}}
-            {{#tab-dropdown
-              tabName='Census'
-              tabNameSmall=''
-              as |item| }}
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Age and Sex'}}>
-                {{#item.scroll-to href='#sex-and-age'}}Age and Sex{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Mutually Exclusive Race / Hispanic Origin'}}>
-                {{#item.scroll-to href='#mutually-exclusive-race-hispanic-origin'}}Mutually Exclusive Race / Hispanic Origin{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Hispanic Subgroup'}}>
-                {{#item.scroll-to href='#hispanic-subgroup'}}Hispanic Subgroup{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Asian Subgroup'}}>
-                {{#item.scroll-to href='#asian-subgroup'}}Asian Subgroup{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Relationship to Head of Household'}}>
-                {{#item.scroll-to href='#relationship-to-head-of-household'}}Relationship to Head of Household{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Household Type'}}>
-                {{#item.scroll-to href='#household-type'}}Household Type{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Housing Occupancy'}}>
-                {{#item.scroll-to href='#housing-occupancy'}}Housing Occupancy{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Housing Tenure'}}>
-                {{#item.scroll-to href='#housing-tenure'}}Housing Tenure{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Tenure by Age of Househodler'}}>
-                {{#item.scroll-to href='#tenure-by-age-of-householder'}}Tenure by Age of Househodler{{/item.scroll-to}}
-              </li>
-              <li onClick={{action 'sendAnalytics' 'Selected Dropdown Item' 'Household Size'}}>
-                {{#item.scroll-to href='#household-size'}}Household Size{{/item.scroll-to}}
-              </li>
-            {{/tab-dropdown}}
+            {{tab-dropdown tabName='Census' tabNameSmall='' dropdown='census'}}
           {{else}}
             {{#link-to
               'profile.census'


### PR DESCRIPTION
The census tab's dropdown menu broke with the last change that refactored how the tab drodowns work. 

See there's just an empty div, all you get is the shadow: 

![image](https://user-images.githubusercontent.com/409279/45238127-c8570580-b2ae-11e8-8e98-b787304d88ab.png)

It was fixed by adding `censusItems` to the `dropdownItems` computed property, just like all the other dropdowns: 

![image](https://user-images.githubusercontent.com/409279/45238186-048a6600-b2af-11e8-838c-54fa0f9cffc1.png)
