### PR TITLE
Support outline for drag-and-drop shapefile

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -251,7 +251,7 @@ export default Controller.extend({
 
         shpjs(buffer).then((geojson) => {
           let combined;
-
+          this.set('customVisualOverlayData', geojson);
           combined = combine(geojson);
           combined = combined.features[0].geometry;
           combined.crs = {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -97,6 +97,30 @@
       {{/map.source}}
     {{/if}}
 
+    {{#if customVisualOverlayData}}
+      {{#map.source
+        sourceId='custom-overlay'
+        options=(hash 
+          type='geojson'
+          data=customVisualOverlayData
+        ) as |source|}}
+        {{source.layer
+          layer=(hash
+            type='line'
+            layout=(hash line-cap='round')
+            paint=(hash 
+              line-color='rgba(255, 0, 185, 1)'
+              line-width=(hash
+                stops=(array (array 6 1.5) (array 12 3))
+              )
+              line-dasharray=(array 0 2)
+            )
+          )
+          before='place_other'}}
+
+      {{/map.source}}
+    {{/if}}
+
     {{map.on 'draw.modechange' (action 'handleDrawModeChange')}}
     {{map.on 'draw.create' (action 'handleDrawCreate')}}
     {{map.on 'click' (action 'handleClick')}}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-import": "^2.12.0",
     "foundation-sites": "^6.4.3",
     "loader.js": "^4.2.3",
-    "mapbox-gl": "^0.45.0"
+    "mapbox-gl": "^0.47.0"
   },
   "engines": {
     "node": "^6.14.0 || ^8.10.0 || >=9.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,10 +224,6 @@
     vfile "^2.3.0"
     vfile-reporter "^4.0.0"
 
-"@mapbox/gl-matrix@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz#e5126aab4d64c36b81c7a97d0ae0dddde5773d2b"
-
 "@mapbox/jsonlint-lines-primitives@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.1.tgz#bc4c1593e2ec2371e2771c518068d6eab8eeae58"
@@ -245,7 +241,7 @@
     lodash.isequal "^4.2.0"
     xtend "^4.0.1"
 
-"@mapbox/mapbox-gl-supported@^1.3.1":
+"@mapbox/mapbox-gl-supported@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz#36946b22944fe2cfa43cfafd5ef36fdb54a069e4"
 
@@ -5654,9 +5650,9 @@ geojson-rewind@^0.3.0:
     minimist "1.2.0"
     sharkdown "^0.1.0"
 
-geojson-vt@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.1.4.tgz#c8ffefbe3613d3ad2747e963b0b63b9e62ff11b8"
+geojson-vt@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.0.tgz#039cea549df5f892c48cff8eb66c2e217d61c241"
 
 get-assigned-identifiers@^1.2.0:
   version "1.2.0"
@@ -5697,6 +5693,10 @@ git-repo-version@^1.0.2:
   resolved "https://registry.yarnpkg.com/git-repo-version/-/git-repo-version-1.0.2.tgz#2c8e9bee5d970cafc0dd58480f9dc56d9afe8e4f"
   dependencies:
     git-repo-info "^1.4.1"
+
+gl-matrix@^2.6.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-2.8.1.tgz#1c7873448eac61d2cd25803a074e837bd42581a3"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -6738,9 +6738,9 @@ jszip@^2.4.0:
   dependencies:
     pako "~1.0.2"
 
-kdbush@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-1.0.1.tgz#3cbd03e9dead9c0f6f66ccdb96450e5cecc640e0"
+kdbush@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-2.0.1.tgz#90c6128e3001ac68c550d7c9e2f222c0269666f1"
 
 keyv@3.0.0:
   version "3.0.0"
@@ -7306,13 +7306,12 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.45.0.tgz#af71cc824f0d7e51ccd5c505eaae411bc0910ccd"
+mapbox-gl@^0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.47.0.tgz#c72f1d3462037f0bb5b8dc25cc8a029513f2b7cd"
   dependencies:
-    "@mapbox/gl-matrix" "^0.0.1"
     "@mapbox/jsonlint-lines-primitives" "^2.0.1"
-    "@mapbox/mapbox-gl-supported" "^1.3.1"
+    "@mapbox/mapbox-gl-supported" "^1.4.0"
     "@mapbox/point-geometry" "^0.1.0"
     "@mapbox/shelf-pack" "^3.1.0"
     "@mapbox/tiny-sdf" "^1.1.0"
@@ -7323,7 +7322,8 @@ mapbox-gl@^0.45.0:
     csscolorparser "~1.0.2"
     earcut "^2.1.3"
     geojson-rewind "^0.3.0"
-    geojson-vt "^3.1.0"
+    geojson-vt "^3.1.4"
+    gl-matrix "^2.6.1"
     gray-matter "^3.0.8"
     grid-index "^1.0.0"
     minimist "0.0.8"
@@ -7332,7 +7332,7 @@ mapbox-gl@^0.45.0:
     rw "^1.3.3"
     shuffle-seed "^1.1.6"
     sort-object "^0.3.2"
-    supercluster "^2.3.0"
+    supercluster "^4.0.1"
     through2 "^2.0.3"
     tinyqueue "^1.1.0"
     vt-pbf "^3.0.1"
@@ -9784,11 +9784,11 @@ sum-up@^1.0.1:
   dependencies:
     chalk "^1.0.0"
 
-supercluster@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-2.3.0.tgz#87ab56081bbea9a1d724df5351ee9e8c3af2f48b"
+supercluster@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-4.1.1.tgz#cf13c3b28a3fb3db5290bfad7f524e244bd4ce78"
   dependencies:
-    kdbush "^1.0.1"
+    kdbush "^2.0.1"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR adds an outline for any polygon shapefiles that are drag-and-dropped into the selection map. This outline is for visual reference.