### PR TITLE
[WIP] Style Dropzone

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -242,8 +242,8 @@ export default Controller.extend({
 
     addedfile(file) {
       const reader = new FileReader();
-      const selection = this.get('selection');
-      const { summaryLevel } = selection;
+      // const selection = this.get('selection');
+      // const { summaryLevel } = selection;
 
       let buffer;
       reader.onload = (event) => {
@@ -261,20 +261,24 @@ export default Controller.extend({
             },
           };
 
-          const SQL = generateIntersectionSQL(summaryLevel, combined);
-          carto.SQL(SQL, 'geojson', 'post')
-            .then((FC) => {
-              selection.handleSelectedFeatures(FC.features);
-              this.fitBounds();
-            })
-            .catch(() => {
-              alert('Something went wrong with this Shapefile. Try to simplify the geometries.'); // eslint-disable-line
-            });
+          // const SQL = generateIntersectionSQL(summaryLevel, combined);
+          // carto.SQL(SQL, 'geojson', 'post')
+          //   .then((FC) => {
+          //     selection.handleSelectedFeatures(FC.features);
+          //     this.fitBounds();
+          //   })
+          //   .catch(() => {
+          //     alert('Something went wrong with this Shapefile. Try to simplify the geometries.'); // eslint-disable-line
+          //   });
         }).catch(() => {
           alert('Something went wrong with this Shapefile. Check that it is valid'); // eslint-disable-line
         });
       };
       reader.readAsArrayBuffer(file);
+    },
+
+    removedfile() {
+      this.set('customVisualOverlayData', null);
     },
   },
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -84,6 +84,7 @@ $lu-gray: #5F5F60;
 // --------------------------------------------------
 @import 'modules/_m-advanced-options';
 @import 'modules/_m-charts';
+@import 'modules/_m-dropzone';
 @import 'modules/_m-ember-tooltip';
 @import 'modules/_m-icons';
 @import 'modules/_m-labs-beta-notice';

--- a/app/styles/modules/_m-dropzone.scss
+++ b/app/styles/modules/_m-dropzone.scss
@@ -1,0 +1,68 @@
+// --------------------------------------------------
+// Module: Dropzone
+// --------------------------------------------------
+.dropzone {
+  color: $dark-gray;
+  border: rem-calc(2) dashed $medium-gray;
+  padding: $global-margin*2;
+  margin: $global-margin;
+  border-radius: rem-calc(4);
+  text-align: center;
+
+  &.dz-clickable {
+    cursor: pointer;
+  }
+
+  .dz-preview {
+    margin: 0;
+    min-height: 0;
+
+    &:not(:last-child) {
+      display: none;
+    }
+
+    .dz-image {
+      display: none;
+    }
+
+    .dz-details {
+      position: relative;
+      font-size: rem-calc(12);
+      color: $black;
+      line-height: 1;
+      padding: 0;
+      margin: 0 0 0.5rem;
+
+      .dz-size {
+        margin-bottom: 0.5em;
+        font-size: rem-calc(16);
+
+        span {
+          background-color: transparent;
+          padding: 0;
+          border-radius: 0;
+        }
+      }
+
+      .dz-filename {
+        span {
+          background-color: transparent;
+          padding: 0;
+          border-radius: 0;
+        }
+      }
+    }
+  }
+
+  .dz-remove {
+    @include button(
+      $expand:false,
+      $background:$light-gray,
+      $background-hover:scale-color($light-gray, $lightness: -15%),
+      $color:$primary-color,
+      $style:solid
+    );
+    text-decoration: none;
+    margin: 0;
+  }
+}

--- a/app/styles/modules/_m-dropzone.scss
+++ b/app/styles/modules/_m-dropzone.scss
@@ -13,6 +13,28 @@
     cursor: pointer;
   }
 
+  .dz-default.dz-message {
+    margin: 0;
+
+    span {
+      display: block;
+    }
+
+    &::after {
+      @include button(
+        $expand:false,
+        $background:$light-gray,
+        $background-hover:$light-gray,
+        $color:$primary-color,
+        $style:solid
+      );
+      content: 'Choose file';
+      font-size: rem-calc(12);
+      text-decoration: none;
+      margin: 0.5em 0 0;
+    }
+  }
+
   .dz-preview {
     margin: 0;
     min-height: 0;
@@ -52,17 +74,18 @@
         }
       }
     }
-  }
 
-  .dz-remove {
-    @include button(
-      $expand:false,
-      $background:$light-gray,
-      $background-hover:scale-color($light-gray, $lightness: -15%),
-      $color:$primary-color,
-      $style:solid
-    );
-    text-decoration: none;
-    margin: 0;
+    .dz-remove {
+      @include button(
+        $expand:false,
+        $background:$light-gray,
+        $background-hover:$light-gray,
+        $color:$primary-color,
+        $style:solid
+      );
+      font-size: rem-calc(12);
+      text-decoration: none;
+      margin: 0;
+    }
   }
 }

--- a/app/styles/modules/_m-dropzone.scss
+++ b/app/styles/modules/_m-dropzone.scss
@@ -14,6 +14,7 @@
   }
 
   .dz-default.dz-message {
+    font-weight: $global-weight-bold;
     margin: 0;
 
     span {
@@ -30,6 +31,7 @@
       );
       content: 'Choose file';
       font-size: rem-calc(12);
+      font-weight: $global-weight-normal;
       text-decoration: none;
       margin: 0.5em 0 0;
     }

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -56,70 +56,70 @@
   <div class="advanced-options {{unless advanced 'closed'}}">
     {{#unless closed}}
 
-    <div class="selection-helpers">
-    </div>
+      <div class="selection-helpers">
+      </div>
 
-    <div class="layers-menu">
-      {{#layer-menu-item for='choropleths' as |item|}}
-        <div class="grid-x">
-          <div class="cell small-8">
-            <ul class="radio-buttons-list">
-              {{#each-in (group-by "group" choroplethConfigs) as |group configs|}}
-                <h5 style="margin:0.5rem 0 0;font-size:1em;">{{group}}</h5>
-                <ul class="no-bullet">
-                  {{#each configs as |config|}}
-                    <li {{
-                      action (
-                        queue
-                          (action 'setChoroplethMode' config.id)
-                          (action item.updatePaintFor 'choropleth-nta-fill' choroplethPaintFill)
-                          (action item.updatePaintFor 'choropleth-nta-line' choroplethPaintLine)
-                      )
-                    }}>
-                      {{#if (eq choroplethMode config.id)}}
-                        {{fa-icon 'dot-circle-o'}}
-                      {{else}}
-                        {{fa-icon 'circle-thin'}}
-                      {{/if}}
-                      {{config.label}}
-                      {{info-tooltip tip=config.tooltip classNames="primary-color"}}
-                    </li>
-                  {{/each}}
-                </ul>
-              {{/each-in}}
-            </ul>
-          </div>
-          <div class="cell small-4">
-            <div class="legend">
-              <div class="legend-title">{{legendTitle}}</div>
-              {{#each stops as |stop|}}
-                <div class="legend-item">
-                  <span class="legend-color" style="color:{{stop.color}};">{{fa-icon 'square'}}</span>
-                  {{stop.label}}
-                </div>
-              {{/each}}
+      <div class="layers-menu">
+        {{#layer-menu-item for='choropleths' as |item|}}
+          <div class="grid-x">
+            <div class="cell small-8">
+              <ul class="radio-buttons-list">
+                {{#each-in (group-by "group" choroplethConfigs) as |group configs|}}
+                  <h5 style="margin:0.5rem 0 0;font-size:1em;">{{group}}</h5>
+                  <ul class="no-bullet">
+                    {{#each configs as |config|}}
+                      <li {{
+                        action (
+                          queue
+                            (action 'setChoroplethMode' config.id)
+                            (action item.updatePaintFor 'choropleth-nta-fill' choroplethPaintFill)
+                            (action item.updatePaintFor 'choropleth-nta-line' choroplethPaintLine)
+                        )
+                      }}>
+                        {{#if (eq choroplethMode config.id)}}
+                          {{fa-icon 'dot-circle-o'}}
+                        {{else}}
+                          {{fa-icon 'circle-thin'}}
+                        {{/if}}
+                        {{config.label}}
+                        {{info-tooltip tip=config.tooltip classNames="primary-color"}}
+                      </li>
+                    {{/each}}
+                  </ul>
+                {{/each-in}}
+              </ul>
+            </div>
+            <div class="cell small-4">
+              <div class="legend">
+                <div class="legend-title">{{legendTitle}}</div>
+                {{#each stops as |stop|}}
+                  <div class="legend-item">
+                    <span class="legend-color" style="color:{{stop.color}};">{{fa-icon 'square'}}</span>
+                    {{stop.label}}
+                  </div>
+                {{/each}}
+              </div>
             </div>
           </div>
-        </div>
-      {{/layer-menu-item}}
-      {{#layer-menu-item for='subway' as |item|}}
-      {{/layer-menu-item}}
-      {{#layer-menu-item for='community-districts' as |item|}}
-      {{/layer-menu-item}}
-      {{#layer-menu-item for='nyccouncildistricts' as |item|}}
-      {{/layer-menu-item}}
-      {{#layer-menu-item for='neighborhood-tabulation-areas' as |item|}}
-      {{/layer-menu-item}}
-      {{#layer-menu-item for='nyc-pumas' as |item|}}
-      {{/layer-menu-item}}
-      {{#layer-menu-item for='boroughs' as |item|}}
-      {{/layer-menu-item}}
-    </div>
+        {{/layer-menu-item}}
+        {{#layer-menu-item for='subway' as |item|}}
+        {{/layer-menu-item}}
+        {{#layer-menu-item for='community-districts' as |item|}}
+        {{/layer-menu-item}}
+        {{#layer-menu-item for='nyccouncildistricts' as |item|}}
+        {{/layer-menu-item}}
+        {{#layer-menu-item for='neighborhood-tabulation-areas' as |item|}}
+        {{/layer-menu-item}}
+        {{#layer-menu-item for='nyc-pumas' as |item|}}
+        {{/layer-menu-item}}
+        {{#layer-menu-item for='boroughs' as |item|}}
+        {{/layer-menu-item}}
+      </div>
+
+      {{yield}}
 
     {{/unless}}
   </div>
-
-  {{yield}}
 
 {{else}}
   {{component mode}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,9 +1,3 @@
-{{drop-zone 
-  url='#' 
-  maxDropRegion=true
-  clickable=false
-  addedfile=(action 'addedfile')}}
-
 <ul class="menu align-center menu--selector">
   <li class="{{if (eq selection.summaryLevel 'blocks') 'active'}} explode-block">
     <a href="#" {{action 'handleSummaryLevelToggle' 'blocks'}}><span class="show-for-medium">Census </span>Block</a>
@@ -100,7 +94,7 @@
     {{#if customVisualOverlayData}}
       {{#map.source
         sourceId='custom-overlay'
-        options=(hash 
+        options=(hash
           type='geojson'
           data=customVisualOverlayData
         ) as |source|}}
@@ -108,7 +102,7 @@
           layer=(hash
             type='line'
             layout=(hash line-cap='round')
-            paint=(hash 
+            paint=(hash
               line-color='rgba(255, 0, 185, 1)'
               line-width=(hash
                 stops=(array (array 6 1.5) (array 12 3))
@@ -128,6 +122,17 @@
 
   {{/jane-maps}}
 </div>
-{{map-utility-box lastreport=lastreport mode=mode drawMode=drawMode handleDrawButtonClick=(action "handleDrawButtonClick")}}
+
+{{#map-utility-box lastreport=lastreport mode=mode drawMode=drawMode handleDrawButtonClick=(action "handleDrawButtonClick")}}
+  {{drop-zone
+    url='#'
+    addedfile=(action 'addedfile')
+    removedfile=(action 'removedfile')
+    dictDefaultMessage='Drag & drop a zipped shapefile here to add it to the map.'
+    createImageThumbnails=false
+    acceptedFiles='application/zip'
+    addRemoveLinks=true
+  }}
+{{/map-utility-box}}
 
 {{outlet}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,9 +10,6 @@ module.exports = function(defaults) {
     'ember-font-awesome': {
       removeUnusedIcons: false,
     },
-    emberCliDropzonejs: {
-      includeDropzoneCss: false,
-    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
This PR… 
- [x] Moves the `{{drop-zone}}` component into the Advanced Options area
- [x] Comments out the code which makes a selection from a dropped shapefile
- [x] Enables Dropzone's default CSS and adds a custom Sass module for overrides 
- [x] Adds a Dropzone param which adds a "Remove file" button
- [x] Adds an `removedfile()` action that sets the `customVisualOverlayData` to null
- [x] Adds a Dropzone param that enforces files must be .zip
- [x] Hides all but the last file uploaded with a `&:not(:last-child) { display: none; }`
  - [ ] **TODO:** ^This leaves an edge case; if you upload 2 files then remove the second, `customVisualOverlayData` is null, but you can see the first file in the Dropzone. Instead of hiding all but the last child with CSS, we should use Dropzone's `.removeFile(file)`. 

![image](https://user-images.githubusercontent.com/409279/47749887-6f7b6c00-dc64-11e8-96c2-b4196df50ed7.png)

![image](https://user-images.githubusercontent.com/409279/47749907-7c985b00-dc64-11e8-97d0-0107a08d5f1b.png)

