### PR TITLE
622 styling

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -260,7 +260,6 @@ export default Controller.extend({
               name: 'EPSG:4326',
             },
           };
-          console.log(combined.type);
           if (combined.type === 'MultiPolygon' || combined.type === 'MultiLineString') {
             this.set('customVisualOverlayLines', true);
           } if (combined.type === 'MultiPoint') {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -260,6 +260,12 @@ export default Controller.extend({
               name: 'EPSG:4326',
             },
           };
+          console.log(combined.type);
+          if (combined.type === 'MultiPolygon' || combined.type === 'MultiLineString') {
+            this.set('customVisualOverlayLines', true);
+          } if (combined.type === 'MultiPoint') {
+            this.set('customVisualOverlayPoints', true);
+          }
 
           // const SQL = generateIntersectionSQL(summaryLevel, combined);
           // carto.SQL(SQL, 'geojson', 'post')

--- a/app/styles/modules/_m-dropzone.scss
+++ b/app/styles/modules/_m-dropzone.scss
@@ -29,7 +29,7 @@
         $color:$primary-color,
         $style:solid
       );
-      content: 'Choose file';
+      content: 'or choose a file';
       font-size: rem-calc(12);
       font-weight: $global-weight-normal;
       text-decoration: none;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -91,7 +91,7 @@
       {{/map.source}}
     {{/if}}
 
-    {{#if customVisualOverlayData}}
+    {{#if customVisualOverlayLines}}
       {{#map.source
         sourceId='custom-overlay'
         options=(hash
@@ -108,6 +108,32 @@
                 stops=(array (array 6 3) (array 12 6))
               )
               line-dasharray=(array 0 2)
+            )
+          )
+          before='place_village'}}
+
+      {{/map.source}}
+    {{/if}}
+
+    {{#if customVisualOverlayPoints}}
+      {{#map.source
+        sourceId='custom-overlay'
+        options=(hash
+          type='geojson'
+          data=customVisualOverlayData
+        ) as |source|}}
+        {{source.layer
+          layer=(hash
+            type='circle'
+            paint=(hash
+              circle-color='rgba(325, 0, 185, 1)'
+              circle-radius=(hash
+                stops=(array (array 9 2) (array 14 3) (array 16 4))
+              )
+              circle-stroke-color='rgba(230, 0, 167, 1)'
+              circle-stroke-width=(hash
+                stops=(array (array 9 1) (array 14 2) (array 16 3))
+              )
             )
           )
           before='place_village'}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -103,14 +103,14 @@
             type='line'
             layout=(hash line-cap='round')
             paint=(hash
-              line-color='rgba(255, 0, 185, 1)'
+              line-color='rgba(325, 0, 185, 1)'
               line-width=(hash
-                stops=(array (array 6 1.5) (array 12 3))
+                stops=(array (array 6 3) (array 12 6))
               )
               line-dasharray=(array 0 2)
             )
           )
-          before='place_other'}}
+          before='place_village'}}
 
       {{/map.source}}
     {{/if}}
@@ -128,7 +128,7 @@
     url='#'
     addedfile=(action 'addedfile')
     removedfile=(action 'removedfile')
-    dictDefaultMessage='Drag & drop a zipped shapefile here to add it to the map.'
+    dictDefaultMessage='Drag & drop a zipped shapefile here to add it as an overlay.'
     createImageThumbnails=false
     acceptedFiles='application/zip'
     addRemoveLinks=true

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -105,7 +105,7 @@
             paint=(hash
               line-color='rgba(325, 0, 185, 1)'
               line-width=(hash
-                stops=(array (array 6 3) (array 12 6))
+                stops=(array (array 11 3) (array 12 6))
               )
               line-dasharray=(array 0 2)
             )

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -101,13 +101,13 @@
         {{source.layer
           layer=(hash
             type='line'
-            layout=(hash line-cap='round')
+            layout=(hash line-cap='butt')
             paint=(hash
-              line-color='rgba(325, 0, 185, 1)'
+              line-color='rgba(255, 0, 185, 0.5)'
               line-width=(hash
                 stops=(array (array 11 3) (array 12 6))
               )
-              line-dasharray=(array 0 2)
+              line-dasharray=(array 1 0.5)
             )
           )
           before='place_village'}}
@@ -126,7 +126,7 @@
           layer=(hash
             type='circle'
             paint=(hash
-              circle-color='rgba(325, 0, 185, 1)'
+              circle-color='rgba(255, 0, 185, 1)'
               circle-radius=(hash
                 stops=(array (array 9 2) (array 14 3) (array 16 4))
               )
@@ -154,7 +154,7 @@
     url='#'
     addedfile=(action 'addedfile')
     removedfile=(action 'removedfile')
-    dictDefaultMessage='Drag & drop a zipped shapefile here to add it as an overlay.'
+    dictDefaultMessage='Drag & drop a zipped shapefile here to add it as an overlay'
     createImageThumbnails=false
     acceptedFiles='application/zip'
     addRemoveLinks=true


### PR DESCRIPTION
This PR updates the styling for the uploaded shapefile overlay and allows points to be displayed.

Changes Proposed:
- Detect geom type of the uploaded shapefile in `controllers/index` and assign a label (customVisualOverlayLines vs. customVisualOverlayPoints) that determines which styling should be applied to it in the template.
- Update`templates/index` to
  - Add styling for points
  - Update line styling to make line thicker and a little darker
  - Render the uploaded lines and points on top of all other preset boundary overlays like CDs, NTAs, etc.
  - Slightly change drag and drop instructions to make overlay functionality more explicit

Closes #622 . Closes #623 