### PR TITLE
617 chart ranges

### DIFF
--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -84,11 +84,14 @@ export default Component.extend(ResizeAware, {
       .paddingOuter(0)
       .paddingInner(0.1);
 
-    const x = scaleLinear()
-      .domain([0, this.get('xMax') ? this.get('xMax') : max(rawData, d => get(d, 'percent'))])
-      .range([textWidth, width]);
+    const xMax = max([
+      max(rawData, d => get(d, 'percent') + get(d, 'percent_m')),
+      max(rawData, d => get(d, 'comparison_percent') + get(d, 'comparison_percent_m')),
+    ]);
 
-    /* eslint-disable */
+    const x = scaleLinear()
+      .domain([0, xMax])
+      .range([textWidth, width]);
 
     // wrap bar type label text to multiple lines
     function wrap(textElements, wrapWidth) {

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -93,6 +93,8 @@ export default Component.extend(ResizeAware, {
       .domain([0, xMax])
       .range([textWidth, width]);
 
+    /* eslint-disable */
+
     // wrap bar type label text to multiple lines
     function wrap(textElements, wrapWidth) {
       textElements.each(function() {

--- a/app/templates/profile/demographic.hbs
+++ b/app/templates/profile/demographic.hbs
@@ -56,8 +56,7 @@
           title="Percent Distribution of Race/Hispanic Origin Groups"
           config=raceGroupChartConfig
           data=model.y2012_2016
-          height=176
-          xMax=1}}
+          height=176}}
       </div>
     {{/if}}
   </div>
@@ -81,8 +80,7 @@
           title="Percent Distribution of Hispanic Subgroups"
           config=hispanicSubgroupChartConfig
           data=model.y2012_2016
-          height=204
-          xMax=1}}
+          height=204}}
       </div>
     {{/if}}
   </div>
@@ -106,8 +104,7 @@
           title="Percent Distribution of Asian Subgroups"
           config=asianSubgroupChartConfig
           data=model.y2012_2016
-          height=150
-          xMax=1}}
+          height=150}}
       </div>
     {{/if}}
   </div>

--- a/app/templates/profile/economic.hbs
+++ b/app/templates/profile/economic.hbs
@@ -42,8 +42,7 @@
           title="Percent Distribution of Workers by Means of Transportation to Work"
           config=commuteToWorkChartConfig
           data=model.y2012_2016
-          height=236
-          xMax=1}}
+          height=236}}
       </div>
     {{/if}}
   </div>
@@ -68,8 +67,7 @@
           title="Percent Distribution of Workers by Occupation"
           config=occupationChartConfig
           data=model.y2012_2016
-          height=204
-          xMax=1}}
+          height=204}}
       </div>
     {{/if}}
   </div>
@@ -110,8 +108,7 @@
           title="Percent Distribution of Workers by Class of Worker"
           config=classOfWorkerChartConfig
           data=model.y2012_2016
-          height=176
-          xMax=1}}
+          height=176}}
       </div>
     {{/if}}
   </div>
@@ -139,8 +136,7 @@
           title="Percent Distribution of Household Income"
           config=incomeAndBenefitsChartConfig
           data=model.y2012_2016
-          height=340
-          xMax=1}}
+          height=340}}
       </div>
     {{/if}}
   </div>
@@ -222,8 +218,7 @@
           title="Percent Distribution of Population by Ratio of Income to Poverty Level"
           config=ratioOfIncomeToPovertyLevelChartConfig
           data=model.y2012_2016
-          height=394
-          xMax=1}}
+          height=394}}
      </div>
    {{/if}}
   </div>

--- a/app/templates/profile/housing.hbs
+++ b/app/templates/profile/housing.hbs
@@ -91,8 +91,7 @@
           title="Percent Distribution of Housing Tenure"
           config=housingTenureChartConfig
           data=model.y2012_2016
-          height=122
-          xMax=1}}
+          height=122}}
       </div>
     {{/if}}
   </div>
@@ -133,8 +132,7 @@
           title="Percent Distribution of Households by Vehicles Available"
           config=vehiclesAvailableChartConfig
           data=model.y2012_2016
-          height=176
-          xMax=1}}
+          height=176}}
       </div>
     {{/if}}
   </div>
@@ -178,8 +176,7 @@
           title="Percent Distribution of Owner-occupied Households by Housing Value"
           config=valueChartConfig
           data=model.y2012_2016
-          height=283
-          xMax=1}}
+          height=283}}
       </div>
     {{/if}}
   </div>
@@ -239,8 +236,7 @@
           title="Percent Distribution of Renter-occupied Households by Gross Rent"
           config=grossRentChartConfig
           data=model.y2012_2016
-          height=264
-          xMax=1}}
+          height=264}}
       </div>
     {{/if}}
   </div>
@@ -265,8 +261,7 @@
           title="Percent Distribution of Renter-occupied Households by Gross Rent as a Percentage of Household Income"
           config=grossRentGrapiChartConfig
           data=model.y2012_2016
-          height=235
-          xMax=1}}
+          height=235}}
       </div>
     {{/if}}
   </div>

--- a/app/templates/profile/social.hbs
+++ b/app/templates/profile/social.hbs
@@ -26,8 +26,7 @@
           title="Percent Distribution of Household Types"
           config=householdTypeChartConfig
           data=model.y2012_2016
-          height=176
-          xMax=1}}
+          height=176}}
       </div>
     {{/if}}
   </div>
@@ -100,8 +99,7 @@
           title="Percent Distribution of Population 3 and Over by School Enrollment"
           config=schoolEnrollmentChartConfig
           data=model.y2012_2016
-          height=204
-          xMax=1}}
+          height=204}}
       </div>
     {{/if}}
   </div>
@@ -126,8 +124,7 @@
           title="Percent Distribution of Population 25 and Over by Educational Attainment"
           config=educationalAttainmentChartConfig
           data=model.y2012_2016
-          height=150
-          xMax=1}}
+          height=150}}
       </div>
     {{/if}}
   </div>
@@ -184,8 +181,7 @@
           title="Percent Distribution of Population who Lived in a Different House 1 Year Ago"
           config=residence1YearAgoChartConfig
           data=model.y2012_2016
-          height=176
-          xMax=1}}
+          height=176}}
       </div>
     {{/if}}
   </div>
@@ -210,14 +206,12 @@
           title="Percent Distribution of Total Population by Place of Birth"
           config=placeOfBirthChartConfig
           data=model.y2012_2016
-          height=150
-          xMax=1}}
+          height=150}}
         {{acs-bar
           title="Percent Distribution of Foreign-Born by World Region of Birth"
           config=foreignBornChartConfig
           data=model.y2012_2016
-          height=176
-          xMax=1}}
+          height=176}}
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
This PR makes all d3 bar charts on the profiles use an X-axis scale that matches the max of the data included on the chart (inclusive of both the selected area and comparison area data + their respective margins of error)

Changes Proposed:
- Calculate xMax in the acs-bar component.
- Remove xMax=1 that has been set in each of the templates where the charts are being inserted.

Closes #617 
