### PR TITLE
Layer Groups Refactor

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -14,12 +14,14 @@ export default Route.extend({
         { id: 'community-districts', visible: false },
         { id: 'boroughs', visible: false },
         { id: 'bk-qn-mh-boundary', visible: true, layers: [{ tooltipable: false }] },
+        { id: 'neighborhood-tabulation-areas', visible: false },
+        { id: 'nyc-pumas', visible: false },
 
         // Census selection groups
-        { id: 'nyc-pumas', visible: false, layers: [{}, {}, {}, { clickable: true }] },
-        { id: 'neighborhood-tabulation-areas', visible: false, layers: [{}, {}, {}, { clickable: true }] },
-        { id: 'census-tracts', visible: true, layers: [{ clickable: true }] },
-        { id: 'census-blocks', visible: false, layers: [{ clickable: true }] },
+        { id: 'factfinder--census-blocks', visible: false },
+        { id: 'factfinder--census-tracts', visible: true },
+        { id: 'factfinder--ntas', visible: false },
+        { id: 'factfinder--pumas', visible: false },
       ],
     });
 

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -104,13 +104,13 @@ export default Service.extend({
     const layerGroupIdMap = (level) => {
       switch (level) {
         case 'tracts':
-          return 'census-tracts';
+          return 'factfinder--census-tracts';
         case 'blocks':
-          return 'census-blocks';
+          return 'factfinder--census-blocks';
         case 'ntas':
-          return 'neighborhood-tabulation-areas';
+          return 'factfinder--ntas';
         case 'pumas':
-          return 'nyc-pumas';
+          return 'factfinder--pumas';
         default:
           return null;
       }


### PR DESCRIPTION
This PR… 
- Separates the layer groups for selecting geometries from the layer groups in advanced options—which fixes a bug where changing the selection geom toggled the layers in adv options and vice-versa. Closes #651.
- Makes the tract styling more prominent while selecting by block. ~Closes #48~ (wrong repo). Closes https://github.com/NYCPlanning/labs-factfinder-api/issues/48. 

This PR relies on https://github.com/NYCPlanning/labs-layers-api/commit/206a0b8d10081ced8b50400726c4e04423576272. So, when this is merged into `master`, the layers API `develop` needs to also be promoted to `master`