### PR TITLE
Reduce outer tick size to 0

### DIFF
--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -165,7 +165,8 @@ export default Component.extend(ResizeAware, {
     const bottomAxis = axisBottom()
       .scale(x)
       .ticks(5)
-      .tickFormat(format('.0%'));
+      .tickFormat(format('.0%'))
+      .tickSizeOuter([0]);
 
     svg.select('.axis-bottom')
       .attr('transform', translation(0, height + 4))


### PR DESCRIPTION
using `.tickSizeOuter([0]);`, reduce the final tick size to 0 for d3 charts

Closes #660 