### PR TITLE
Change geom highlight color to grey

### DIFF
--- a/app/components/labs-map.js
+++ b/app/components/labs-map.js
@@ -8,7 +8,7 @@ export const highlightedFeatureLayer = {
   type: 'line',
   source: 'hovered-feature',
   paint: {
-    'line-color': '#D3D3D3',
+    'line-color': '#585858',
     'line-opacity': 0.3,
     'line-width': {
       stops: [

--- a/app/components/labs-map.js
+++ b/app/components/labs-map.js
@@ -3,10 +3,28 @@ import { ParentMixin } from 'ember-composability-tools';
 import { inject as service } from '@ember/service';
 import layout from '../templates/components/labs-map';
 
+export const highlightedFeatureLayer = {
+  id: 'highlighted-feature',
+  type: 'line',
+  source: 'hovered-feature',
+  paint: {
+    'line-color': '#D3D3D3',
+    'line-opacity': 0.3,
+    'line-width': {
+      stops: [
+        [8, 4],
+        [11, 7],
+      ],
+    },
+  },
+};
+
 export default LabsMap.extend(ParentMixin, {
   layout,
 
   registeredLayers: service(),
+
+  highlightedFeatureLayer,
 
   init(...args) {
     this._super(...args);


### PR DESCRIPTION
added `highlightedFeatureLayer` from ember-labs-composer to `labs-map.js`, edited line color to grey


Closes #664 