### PR TITLE
665 geom layer bug

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -205,6 +205,12 @@ export default Controller.extend({
       // remove default neighborhood names
       map.removeLayer('place_suburb');
       map.removeLayer('place_city_large');
+
+      map.addLayer(subduedNtaLabels);
+
+      // trigger handleSummaryLevelToggle to show the correct census geoms
+      const summaryLevel = this.get('summaryLevel');
+      this.send('handleSummaryLevelToggle', summaryLevel);
     },
 
     addedfile(file) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -19,7 +19,7 @@ export default Route.extend({
 
         // Census selection groups
         { id: 'factfinder--census-blocks', visible: false },
-        { id: 'factfinder--census-tracts', visible: true },
+        { id: 'factfinder--census-tracts', visible: false },
         { id: 'factfinder--ntas', visible: false },
         { id: 'factfinder--pumas', visible: false },
       ],

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -99,6 +99,7 @@ export default Service.extend({
   // methods
   handleSummaryLevelToggle(toLevel) {
     const fromLevel = this.get('summaryLevel');
+
     this.set('summaryLevel', toLevel);
 
     const layerGroupIdMap = (level) => {
@@ -156,18 +157,20 @@ export default Service.extend({
 
   // target table is the TO and filter ID is the FROM;
   explode(fromLevel, toLevel) {
-    const crossWalkFromColumn = SUM_LEVEL_DICT[toLevel][fromLevel];
-    const crossWalkToTable = SUM_LEVEL_DICT[toLevel].sql;
+    if (fromLevel !== toLevel) {
+      const crossWalkFromColumn = SUM_LEVEL_DICT[toLevel][fromLevel];
+      const crossWalkToTable = SUM_LEVEL_DICT[toLevel].sql;
 
-    const filterIds = findUniqueBy(this.get('current.features'), crossWalkFromColumn).join("','");
-    const sqlQuery = `SELECT * FROM (${crossWalkToTable}) a WHERE ${crossWalkFromColumn} IN ('${filterIds}')`;
+      const filterIds = findUniqueBy(this.get('current.features'), crossWalkFromColumn).join("','");
+      const sqlQuery = `SELECT * FROM (${crossWalkToTable}) a WHERE ${crossWalkFromColumn} IN ('${filterIds}')`;
 
 
-    carto.SQL(sqlQuery, 'geojson')
-      .then((json) => {
-        this.clearSelection();
-        this.set('current', json);
-      });
+      carto.SQL(sqlQuery, 'geojson')
+        .then((json) => {
+          this.clearSelection();
+          this.set('current', json);
+        });
+    }
   },
 
   explodeGeo(fromLevel, toLevel) {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -42,9 +42,6 @@
       {{/layers.tooltip}}
     {{/map.labs-layers}}
 
-    {{!-- TODO --}}
-    {{map.layer layer=subduedNtaLabels}}
-
     {{#if selection.currentAddress}}
       {{#map.source sourceId='currentAddress' options=selection.addressSource as |source|}}
         {{source.layer layer=selection.pointLayer}}


### PR DESCRIPTION
This PR addresses the bug where census tracts are showing when navigating back to the index route from a profile.

- All of the `factinder--` prefixed census geometry layergroups are now set to `visible:false` in the route.
- `handleSummaryLevelToggle()` is triggered at the end of `handleMapLoad()` (after the map loads, make the appropriate census geometry layer visible)
- The subdued NTA labels layer is now added in javascript in `handleMapLoad()`, as it needs to exist on the map before we turn on the census geometries. 


Closes #665
