### PR TITLE
567 CSV download

### DIFF
--- a/app/components/download-spreadsheet.js
+++ b/app/components/download-spreadsheet.js
@@ -15,6 +15,7 @@ export default Component.extend({
         eventCategory: 'Data',
         eventAction: 'Downloaded CSV',
       });
+
       const filename = this.get('filename');
       const profile = this.get('data');
       const mode = this.get('mode');
@@ -24,12 +25,17 @@ export default Component.extend({
         if (tab !== 'profile.census') {
           profile.map((row) => {
             const truncatedRow = row;
-            // if (truncatedRow.dataset === 'y2006_2010') {
-            //   delete truncatedRow;
-            // }
             delete truncatedRow.codingThresholds;
             delete truncatedRow.rowConfig;
             delete truncatedRow.notinprofile;
+            delete truncatedRow.variablename;
+            delete truncatedRow.year;
+            delete truncatedRow.is_most_recent;
+            delete truncatedRow.geotype;
+            delete truncatedRow.producttype;
+            delete truncatedRow.release_year;
+            delete truncatedRow.unittype;
+            delete truncatedRow.special;
             delete truncatedRow.previous_sum;
             delete truncatedRow.previous_m;
             delete truncatedRow.previous_cv;
@@ -54,6 +60,14 @@ export default Component.extend({
             delete truncatedRow.codingThresholds;
             delete truncatedRow.rowConfig;
             delete truncatedRow.notinprofile;
+            delete truncatedRow.variablename;
+            delete truncatedRow.year;
+            delete truncatedRow.is_most_recent;
+            delete truncatedRow.geotype;
+            delete truncatedRow.producttype;
+            delete truncatedRow.release_year;
+            delete truncatedRow.unittype;
+            delete truncatedRow.special;
             delete truncatedRow.base;
             delete truncatedRow.m;
             delete truncatedRow.cv;
@@ -75,7 +89,7 @@ export default Component.extend({
             delete truncatedRow.previous_is_reliable;
             delete truncatedRow.change_sum;
             delete truncatedRow.change_m;
-            delete truncatedRow.change_significant;
+            delete truncatedRow.change_reliable;
             delete truncatedRow.change_percent;
             delete truncatedRow.change_percent_m;
             delete truncatedRow.change_percent_reliable;
@@ -83,7 +97,8 @@ export default Component.extend({
             delete truncatedRow.change_percentage_point_m;
             delete truncatedRow.change_percentage_point_reliable;
             return truncatedRow;
-          });
+          })
+            .sortBy('dataset', 'profile', 'category').reverse();
         }
       } else if (mode === 'change') {
         if (tab !== 'profile.census') {
@@ -92,6 +107,14 @@ export default Component.extend({
             delete truncatedRow.codingThresholds;
             delete truncatedRow.rowConfig;
             delete truncatedRow.notinprofile;
+            delete truncatedRow.variablename;
+            delete truncatedRow.year;
+            delete truncatedRow.is_most_recent;
+            delete truncatedRow.geotype;
+            delete truncatedRow.producttype;
+            delete truncatedRow.release_year;
+            delete truncatedRow.unittype;
+            delete truncatedRow.special;
             delete truncatedRow.comparison_sum;
             delete truncatedRow.comparison_m;
             delete truncatedRow.comparison_cv;
@@ -113,6 +136,14 @@ export default Component.extend({
             delete truncatedRow.codingThresholds;
             delete truncatedRow.rowConfig;
             delete truncatedRow.notinprofile;
+            delete truncatedRow.variablename;
+            delete truncatedRow.year;
+            delete truncatedRow.is_most_recent;
+            delete truncatedRow.geotype;
+            delete truncatedRow.producttype;
+            delete truncatedRow.release_year;
+            delete truncatedRow.unittype;
+            delete truncatedRow.special;
             delete truncatedRow.base;
             delete truncatedRow.m;
             delete truncatedRow.cv;
@@ -135,29 +166,32 @@ export default Component.extend({
             delete truncatedRow.previous_percent_m;
             delete truncatedRow.previous_is_reliable;
             delete truncatedRow.change_m;
-            delete truncatedRow.change_significant;
+            delete truncatedRow.change_reliable;
             delete truncatedRow.change_percent_m;
-            delete truncatedRow.change_percent_significant;
+            delete truncatedRow.change_percent_reliable;
             delete truncatedRow.change_percentage_point_m;
-            delete truncatedRow.change_percentage_point_significant;
+            delete truncatedRow.change_percentage_point_reliable;
             return truncatedRow;
           })
             .sortBy('dataset', 'profile', 'category').reverse();
         }
       }
 
-      const columnNames = [Object.keys(profile.get('firstObject'))];
-      const matrixValues = profile.map(row => Object.values(row));
+      // remove all rows with years 2006-2010 from the ACS tables and year 2000 from the census table
+      function removeEarlier(prof) {
+        return prof.filter(d => d.dataset !== 'y2006_2010' && d.dataset !== 'y2000');
+      }
+
+      const recentProfile = removeEarlier(profile);
+
+      const columnNames = [Object.keys(recentProfile.get('firstObject'))];
+      const matrixValues = recentProfile.map(row => Object.values(row));
 
       const data = []
         .concat(
           columnNames,
           matrixValues,
         );
-
-      console.log(data);
-      console.log('mode', mode);
-      console.log('tab', tab);
 
       if (format === 'csv') {
         this.get('csv').export(data, { fileName: `${filename}.csv`, withSeparator: false });

--- a/app/components/download-spreadsheet.js
+++ b/app/components/download-spreadsheet.js
@@ -5,6 +5,7 @@ export default Component.extend({
   tagName: '',
   data: null, // []
   mode: '',
+  tab: '',
   filename: 'download',
   csv: service('csv'),
   metrics: service('metrics'),
@@ -17,52 +18,132 @@ export default Component.extend({
       const filename = this.get('filename');
       const profile = this.get('data');
       const mode = this.get('mode');
+      const tab = this.get('tab');
 
       if (mode === 'current') {
-        profile.map((row) => {
-          const truncatedRow = row;
-          delete truncatedRow.codingThresholds;
-          delete truncatedRow.rowConfig;
-          delete truncatedRow.notinprofile;
-          delete truncatedRow.previous_sum;
-          delete truncatedRow.previous_m;
-          delete truncatedRow.previous_cv;
-          delete truncatedRow.previous_percent;
-          delete truncatedRow.previous_percent_m;
-          delete truncatedRow.previous_is_reliable;
-          delete truncatedRow.change_sum;
-          delete truncatedRow.change_m;
-          delete truncatedRow.change_significant;
-          delete truncatedRow.change_percent;
-          delete truncatedRow.change_percent_m;
-          delete truncatedRow.change_percent_reliable;
-          delete truncatedRow.change_percentage_point;
-          delete truncatedRow.change_percentage_point_m;
-          delete truncatedRow.change_percentage_point_reliable;
-          return truncatedRow;
-        })
-          .sortBy('dataset', 'profile', 'category').reverse();
+        if (tab !== 'profile.census') {
+          profile.map((row) => {
+            const truncatedRow = row;
+            // if (truncatedRow.dataset === 'y2006_2010') {
+            //   delete truncatedRow;
+            // }
+            delete truncatedRow.codingThresholds;
+            delete truncatedRow.rowConfig;
+            delete truncatedRow.notinprofile;
+            delete truncatedRow.previous_sum;
+            delete truncatedRow.previous_m;
+            delete truncatedRow.previous_cv;
+            delete truncatedRow.previous_percent;
+            delete truncatedRow.previous_percent_m;
+            delete truncatedRow.previous_is_reliable;
+            delete truncatedRow.change_sum;
+            delete truncatedRow.change_m;
+            delete truncatedRow.change_significant;
+            delete truncatedRow.change_percent;
+            delete truncatedRow.change_percent_m;
+            delete truncatedRow.change_percent_reliable;
+            delete truncatedRow.change_percentage_point;
+            delete truncatedRow.change_percentage_point_m;
+            delete truncatedRow.change_percentage_point_reliable;
+            return truncatedRow;
+          })
+            .sortBy('dataset', 'profile', 'category').reverse();
+        } else if (tab === 'profile.census') {
+          profile.map((row) => {
+            const truncatedRow = row;
+            delete truncatedRow.codingThresholds;
+            delete truncatedRow.rowConfig;
+            delete truncatedRow.notinprofile;
+            delete truncatedRow.base;
+            delete truncatedRow.m;
+            delete truncatedRow.cv;
+            delete truncatedRow.percent_m;
+            delete truncatedRow.is_reliable;
+            delete truncatedRow.comparison_m;
+            delete truncatedRow.comparison_cv;
+            delete truncatedRow.comparison_percent_m;
+            delete truncatedRow.comparison_is_reliable;
+            delete truncatedRow.difference_m;
+            delete truncatedRow.significant;
+            delete truncatedRow.difference_percent_m;
+            delete truncatedRow.percent_significant;
+            delete truncatedRow.previous_sum;
+            delete truncatedRow.previous_m;
+            delete truncatedRow.previous_cv;
+            delete truncatedRow.previous_percent;
+            delete truncatedRow.previous_percent_m;
+            delete truncatedRow.previous_is_reliable;
+            delete truncatedRow.change_sum;
+            delete truncatedRow.change_m;
+            delete truncatedRow.change_significant;
+            delete truncatedRow.change_percent;
+            delete truncatedRow.change_percent_m;
+            delete truncatedRow.change_percent_reliable;
+            delete truncatedRow.change_percentage_point;
+            delete truncatedRow.change_percentage_point_m;
+            delete truncatedRow.change_percentage_point_reliable;
+            return truncatedRow;
+          });
+        }
       } else if (mode === 'change') {
-        profile.map((row) => {
-          const truncatedRow = row;
-          delete truncatedRow.codingThresholds;
-          delete truncatedRow.rowConfig;
-          delete truncatedRow.notinprofile;
-          delete truncatedRow.comparison_sum;
-          delete truncatedRow.comparison_m;
-          delete truncatedRow.comparison_cv;
-          delete truncatedRow.comparison_percent;
-          delete truncatedRow.comparison_percent_m;
-          delete truncatedRow.comparison_is_reliable;
-          delete truncatedRow.difference_sum;
-          delete truncatedRow.difference_m;
-          delete truncatedRow.significant;
-          delete truncatedRow.difference_percent;
-          delete truncatedRow.difference_percent_m;
-          delete truncatedRow.percent_significant;
-          return truncatedRow;
-        })
-          .sortBy('dataset', 'profile', 'category').reverse();
+        if (tab !== 'profile.census') {
+          profile.map((row) => {
+            const truncatedRow = row;
+            delete truncatedRow.codingThresholds;
+            delete truncatedRow.rowConfig;
+            delete truncatedRow.notinprofile;
+            delete truncatedRow.comparison_sum;
+            delete truncatedRow.comparison_m;
+            delete truncatedRow.comparison_cv;
+            delete truncatedRow.comparison_percent;
+            delete truncatedRow.comparison_percent_m;
+            delete truncatedRow.comparison_is_reliable;
+            delete truncatedRow.difference_sum;
+            delete truncatedRow.difference_m;
+            delete truncatedRow.significant;
+            delete truncatedRow.difference_percent;
+            delete truncatedRow.difference_percent_m;
+            delete truncatedRow.percent_significant;
+            return truncatedRow;
+          })
+            .sortBy('dataset', 'profile', 'category').reverse();
+        } else if (tab === 'profile.census') {
+          profile.map((row) => {
+            const truncatedRow = row;
+            delete truncatedRow.codingThresholds;
+            delete truncatedRow.rowConfig;
+            delete truncatedRow.notinprofile;
+            delete truncatedRow.base;
+            delete truncatedRow.m;
+            delete truncatedRow.cv;
+            delete truncatedRow.percent_m;
+            delete truncatedRow.is_reliable;
+            delete truncatedRow.comparison_sum;
+            delete truncatedRow.comparison_m;
+            delete truncatedRow.comparison_cv;
+            delete truncatedRow.comparison_percent;
+            delete truncatedRow.comparison_percent_m;
+            delete truncatedRow.comparison_is_reliable;
+            delete truncatedRow.difference_sum;
+            delete truncatedRow.difference_m;
+            delete truncatedRow.significant;
+            delete truncatedRow.difference_percent;
+            delete truncatedRow.difference_percent_m;
+            delete truncatedRow.percent_significant;
+            delete truncatedRow.previous_m;
+            delete truncatedRow.previous_cv;
+            delete truncatedRow.previous_percent_m;
+            delete truncatedRow.previous_is_reliable;
+            delete truncatedRow.change_m;
+            delete truncatedRow.change_significant;
+            delete truncatedRow.change_percent_m;
+            delete truncatedRow.change_percent_significant;
+            delete truncatedRow.change_percentage_point_m;
+            delete truncatedRow.change_percentage_point_significant;
+            return truncatedRow;
+          })
+            .sortBy('dataset', 'profile', 'category').reverse();
+        }
       }
 
       const columnNames = [Object.keys(profile.get('firstObject'))];
@@ -75,7 +156,8 @@ export default Component.extend({
         );
 
       console.log(data);
-      console.log(mode);
+      console.log('mode', mode);
+      console.log('tab', tab);
 
       if (format === 'csv') {
         this.get('csv').export(data, { fileName: `${filename}.csv`, withSeparator: false });

--- a/app/components/download-spreadsheet.js
+++ b/app/components/download-spreadsheet.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   tagName: '',
   data: null, // []
+  mode: '',
   filename: 'download',
   csv: service('csv'),
   metrics: service('metrics'),
@@ -14,14 +15,56 @@ export default Component.extend({
         eventAction: 'Downloaded CSV',
       });
       const filename = this.get('filename');
-      const profile = this.get('data')
-        .map((row) => {
+      const profile = this.get('data');
+      const mode = this.get('mode');
+
+      if (mode === 'current') {
+        profile.map((row) => {
           const truncatedRow = row;
           delete truncatedRow.codingThresholds;
           delete truncatedRow.rowConfig;
+          delete truncatedRow.notinprofile;
+          delete truncatedRow.previous_sum;
+          delete truncatedRow.previous_m;
+          delete truncatedRow.previous_cv;
+          delete truncatedRow.previous_percent;
+          delete truncatedRow.previous_percent_m;
+          delete truncatedRow.previous_is_reliable;
+          delete truncatedRow.change_sum;
+          delete truncatedRow.change_m;
+          delete truncatedRow.change_significant;
+          delete truncatedRow.change_percent;
+          delete truncatedRow.change_percent_m;
+          delete truncatedRow.change_percent_reliable;
+          delete truncatedRow.change_percentage_point;
+          delete truncatedRow.change_percentage_point_m;
+          delete truncatedRow.change_percentage_point_reliable;
           return truncatedRow;
         })
-        .sortBy('dataset', 'profile', 'category').reverse();
+          .sortBy('dataset', 'profile', 'category').reverse();
+      } else if (mode === 'change') {
+        profile.map((row) => {
+          const truncatedRow = row;
+          delete truncatedRow.codingThresholds;
+          delete truncatedRow.rowConfig;
+          delete truncatedRow.notinprofile;
+          delete truncatedRow.comparison_sum;
+          delete truncatedRow.comparison_m;
+          delete truncatedRow.comparison_cv;
+          delete truncatedRow.comparison_percent;
+          delete truncatedRow.comparison_percent_m;
+          delete truncatedRow.comparison_is_reliable;
+          delete truncatedRow.difference_sum;
+          delete truncatedRow.difference_m;
+          delete truncatedRow.significant;
+          delete truncatedRow.difference_percent;
+          delete truncatedRow.difference_percent_m;
+          delete truncatedRow.percent_significant;
+          return truncatedRow;
+        })
+          .sortBy('dataset', 'profile', 'category').reverse();
+      }
+
       const columnNames = [Object.keys(profile.get('firstObject'))];
       const matrixValues = profile.map(row => Object.values(row));
 
@@ -30,6 +73,9 @@ export default Component.extend({
           columnNames,
           matrixValues,
         );
+
+      console.log(data);
+      console.log(mode);
 
       if (format === 'csv') {
         this.get('csv').export(data, { fileName: `${filename}.csv`, withSeparator: false });

--- a/app/models/row.js
+++ b/app/models/row.js
@@ -3,9 +3,12 @@ import DS from 'ember-data';
 import { computed } from '@ember/object';
 
 export default DS.Model.extend({
+  // number of geoids
+  numGeoids: DS.attr('number'),
+
   // categorical information
-  category: DS.attr('string'),
   profile: DS.attr('string'),
+  category: DS.attr('string'),
   variable: DS.attr('string'),
   variablename: DS.attr('string'),
   dataset: DS.attr('string'), // year
@@ -22,45 +25,50 @@ export default DS.Model.extend({
   */
   geotype: DS.attr('string'),
 
-  // number of geoids
-  numGeoids: DS.attr('number'),
-
   // all data
   base: DS.attr('string'),
+
+  previous_sum: DS.attr('number'),
+  previous_m: DS.attr('number'),
+  previous_cv: DS.attr('number'),
+  previous_percent: DS.attr('number'),
+  previous_percent_m: DS.attr('number'),
+  pervious_is_reliable: DS.attr('boolean'),
+
+  sum: DS.attr('number'),
+  m: DS.attr('number'),
+  cv: DS.attr('number'),
+  percent: DS.attr('number'),
+  percent_m: DS.attr('number'),
+  is_reliable: DS.attr('boolean'),
+
+  change_sum: DS.attr('number'),
+  change_m: DS.attr('number'),
+  change_reliable: DS.attr('boolean'),
+  change_percent: DS.attr('number'),
+  change_percent_m: DS.attr('number'),
+  change_percent_reliable: DS.attr('boolean'),
+  change_percentage_point: DS.attr('number'),
+  change_percentage_point_m: DS.attr('number'),
+  change_percentage_point_reliable: DS.attr('boolean'),
+
   comparison_cv: DS.attr('number'),
   comparison_m: DS.attr('number'),
   comparison_percent: DS.attr('number'),
   comparison_percent_m: DS.attr('number'),
   comparison_sum: DS.attr('number'),
-  cv: DS.attr('number'),
-  m: DS.attr('number'),
+  comparison_is_reliable: DS.attr('boolean'),
+
   difference_sum: DS.attr('number'),
   difference_percent: DS.attr('number'),
   difference_m: DS.attr('number'),
   difference_percent_m: DS.attr('number'),
 
-  previous_sum: DS.attr('number'),
-  change_sum: DS.attr('number'),
-  change_percent: DS.attr('number'),
-  change_m: DS.attr('number'),
-  change_percent_m: DS.attr('number'),
-  change_percentage_point: DS.attr('number'),
-  change_percentage_point_m: DS.attr('number'),
-  change_significant: DS.attr('number'),
-  change_percent_significant: DS.attr('number'),
-  change_percentage_point_significant: DS.attr('number'),
-
   notinprofile: DS.attr('string'),
-  percent: DS.attr('number'),
-  percent_m: DS.attr('number'),
-  previous_percent: DS.attr('number'),
   percent_significant: DS.attr('boolean'),
   producttype: DS.attr('string'),
   release_year: DS.attr('string'),
   significant: DS.attr('boolean'),
-  is_reliable: DS.attr('boolean'),
-  comparison_is_reliable: DS.attr('boolean'),
-  sum: DS.attr('number'),
   unittype: DS.attr('string'),
 
   // groupings
@@ -117,6 +125,7 @@ export default DS.Model.extend({
       };
     },
   ),
+
 
   isBase: computed('base', 'variablename', function() {
     const { base, variablename } = this.getProperties('base', 'variablename');

--- a/app/models/row.js
+++ b/app/models/row.js
@@ -33,7 +33,7 @@ export default DS.Model.extend({
   previous_cv: DS.attr('number'),
   previous_percent: DS.attr('number'),
   previous_percent_m: DS.attr('number'),
-  pervious_is_reliable: DS.attr('boolean'),
+  previous_is_reliable: DS.attr('boolean'),
 
   sum: DS.attr('number'),
   m: DS.attr('number'),
@@ -52,23 +52,23 @@ export default DS.Model.extend({
   change_percentage_point_m: DS.attr('number'),
   change_percentage_point_reliable: DS.attr('boolean'),
 
-  comparison_cv: DS.attr('number'),
+  comparison_sum: DS.attr('number'),
   comparison_m: DS.attr('number'),
+  comparison_cv: DS.attr('number'),
   comparison_percent: DS.attr('number'),
   comparison_percent_m: DS.attr('number'),
-  comparison_sum: DS.attr('number'),
   comparison_is_reliable: DS.attr('boolean'),
 
   difference_sum: DS.attr('number'),
-  difference_percent: DS.attr('number'),
   difference_m: DS.attr('number'),
+  significant: DS.attr('boolean'),
+  difference_percent: DS.attr('number'),
   difference_percent_m: DS.attr('number'),
+  percent_significant: DS.attr('boolean'),
 
   notinprofile: DS.attr('string'),
-  percent_significant: DS.attr('boolean'),
   producttype: DS.attr('string'),
   release_year: DS.attr('string'),
-  significant: DS.attr('boolean'),
   unittype: DS.attr('string'),
 
   // groupings

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -40,7 +40,7 @@
     </span>
     View Profile
     <small><strong>
-      <span class="count">{{selectionCount}}</span>
+      <span class="count" data-test-toggle-count>{{selectionCount}}</span>
       {{if (eq summaryLevel 'tracts') 'Tract'~}}
       {{if (eq summaryLevel 'blocks') 'Block'~}}
       {{if (eq summaryLevel 'ntas') 'Neighborhood'~}}

--- a/app/templates/components/profile-header.hbs
+++ b/app/templates/components/profile-header.hbs
@@ -3,7 +3,7 @@
 
     <h1 id="top">
       {{title}}
-      {{download-spreadsheet data=data mode=mode}}
+      {{download-spreadsheet data=data mode=mode tab=profile.tab}}
     </h1>
 
     <div class="profile-mode">

--- a/app/templates/components/profile-header.hbs
+++ b/app/templates/components/profile-header.hbs
@@ -3,7 +3,7 @@
 
     <h1 id="top">
       {{title}}
-      {{download-spreadsheet data=data}}
+      {{download-spreadsheet data=data mode=mode}}
     </h1>
 
     <div class="profile-mode">

--- a/tests/acceptance/user-can-toggle-between-geometries-test.js
+++ b/tests/acceptance/user-can-toggle-between-geometries-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click } from '@ember/test-helpers';
+import { visit, currentURL, click, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import random from '@turf/random';
 import SelectionService from 'labs-nyc-factfinder/services/selection';
@@ -16,17 +16,25 @@ module('Acceptance | user can toggle between geometries', function(hooks) {
 
     await click('[data-test-toggle-blocks]');
 
+    await waitFor('[data-test-toggle-count]'); // wait until the new count loads in View Profile button
+
     assert.equal(selectionService.get('selectedCount'), 113);
 
     await click('[data-test-toggle-ntas]');
+
+    await waitFor('[data-test-toggle-count]');
 
     assert.equal(selectionService.get('selectedCount'), 4);
 
     await click('[data-test-toggle-tracts]');
 
+    await waitFor('[data-test-toggle-count]');
+
     assert.equal(selectionService.get('selectedCount'), 69);
 
     await click('[data-test-toggle-pumas]');
+
+    await waitFor('[data-test-toggle-count]');
 
     assert.equal(selectionService.get('selectedCount'), 2);
 


### PR DESCRIPTION
This PR updates the CSV download:

**- For ACS profiles**
-removes 2006-2010 rows
-displays reliability and significant columns as TRUE/FALSE
-reorders and removes columns based on attached file in issue #567 
-`change` and `difference` columns changed to `reliable` rather than `significant`

**- For Census**
-removes 2000 rows
-reorders and removes columns based on attached file in issue #567 

Closes #567 