### PR TITLE
685 MOE bar fix

### DIFF
--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -227,6 +227,14 @@ export default Component.extend(ResizeAware, {
       return defaultWidth;
     };
 
+    svg.append('defs').append('clipPath') // define a clip path
+      .attr('id', 'chart-clip') // give the clipPath an ID
+      .append('rect') // shape it as a rectangle
+      .attr('x', x(0))
+      .attr('y', y(0))
+      .attr('width', 235)
+      .attr('height', height + 4);
+
     moebars.enter()
       .append('rect')
       .attr('class', d => `moebar ${get(d, 'classValue')}`)
@@ -242,7 +250,8 @@ export default Component.extend(ResizeAware, {
 
     moebars.transition().duration(300)
       .attr('x', xFunctionMOE)
-      .attr('width', widthFunctionMOE);
+      .attr('width', widthFunctionMOE)
+      .attr('clip-path', 'url(#chart-clip)');
 
     moebars.exit().remove();
 

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -223,7 +223,6 @@ export default Component.extend(ResizeAware, {
       const barWidth = x(get(d, 'percent')) - textWidth;
       if (get(d, 'percent_m') > get(d, 'percent')) {
         const newWidth = defaultWidth - (x(get(d, 'percent_m') - get(d, 'percent')) - textWidth);
-        console.log('new width', newWidth);
         return newWidth;
       }
       // if the percentage bar + the MOE bar extend past 100% on the x axes, modify width of MOE bar

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -219,22 +219,22 @@ export default Component.extend(ResizeAware, {
 
     const widthFunctionMOE = (d) => {
       const defaultWidth = (x(get(d, 'percent_m')) - textWidth) * 2;
+      const axesWidth = width - textWidth;
+      const barWidth = x(get(d, 'percent')) - textWidth;
       if (get(d, 'percent_m') > get(d, 'percent')) {
         const newWidth = defaultWidth - (x(get(d, 'percent_m') - get(d, 'percent')) - textWidth);
+        console.log('new width', newWidth);
         return newWidth;
       }
+      // if the percentage bar + the MOE bar extend past 100% on the x axes, modify width of MOE bar
+      if (barWidth + (defaultWidth * 0.5) > axesWidth) {
+        const gapWidth = axesWidth - barWidth;
+        const shortenedWidth = (defaultWidth * 0.5) + gapWidth;
+        return shortenedWidth;
+      }
+
       return defaultWidth;
     };
-
-    // create a rectangular clip path that covers the full chart from left edge of bottom axis to right edge of bottom axis
-    // this assures that anything outside of the clip path is not shown, add this as an attribute to moebars.transition
-    svg.append('defs').append('clipPath') // define a clip path
-      .attr('id', 'moebar-clip') // give the clipPath an ID
-      .append('rect') // shape it as a rectangle
-      .attr('x', x(0))
-      .attr('y', y(0))
-      .attr('width', width - textWidth)
-      .attr('height', height);
 
     moebars.enter()
       .append('rect')
@@ -251,8 +251,7 @@ export default Component.extend(ResizeAware, {
 
     moebars.transition().duration(300)
       .attr('x', xFunctionMOE)
-      .attr('width', widthFunctionMOE)
-      .attr('clip-path', 'url(#moebar-clip)');
+      .attr('width', widthFunctionMOE);
 
     moebars.exit().remove();
 

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -84,13 +84,19 @@ export default Component.extend(ResizeAware, {
       .paddingOuter(0)
       .paddingInner(0.1);
 
+    // function to limit the maximum value to 100%
+    function limitMax(newMax) {
+      if (newMax > 1) return 1;
+      return newMax;
+    }
+
     const xMax = max([
       max(rawData, d => get(d, 'percent') + get(d, 'percent_m')),
       max(rawData, d => get(d, 'comparison_percent') + get(d, 'comparison_percent_m')),
     ]);
 
     const x = scaleLinear()
-      .domain([0, xMax])
+      .domain([0, limitMax(xMax)])
       .range([textWidth, width]);
 
     /* eslint-disable */

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -76,7 +76,6 @@ export default Component.extend(ResizeAware, {
       .attr('width', width + margin.left + margin.right)
       .attr('height', height + margin.top + margin.bottom);
 
-
     const rawData = mungeBarChartData(config, data);
     const y = scaleBand()
       .domain(rawData.map(d => get(d, 'group')))
@@ -227,13 +226,15 @@ export default Component.extend(ResizeAware, {
       return defaultWidth;
     };
 
+    // create a rectangular clip path that covers the full chart from left edge of bottom axis to right edge of bottom axis
+    // this assures that anything outside of the clip path is not shown, add this as an attribute to moebars.transition
     svg.append('defs').append('clipPath') // define a clip path
-      .attr('id', 'chart-clip') // give the clipPath an ID
+      .attr('id', 'moebar-clip') // give the clipPath an ID
       .append('rect') // shape it as a rectangle
       .attr('x', x(0))
       .attr('y', y(0))
-      .attr('width', 236)
-      .attr('height', 200);
+      .attr('width', width - textWidth)
+      .attr('height', height);
 
     moebars.enter()
       .append('rect')
@@ -251,7 +252,7 @@ export default Component.extend(ResizeAware, {
     moebars.transition().duration(300)
       .attr('x', xFunctionMOE)
       .attr('width', widthFunctionMOE)
-      .attr('clip-path', 'url(#chart-clip)');
+      .attr('clip-path', 'url(#moebar-clip)');
 
     moebars.exit().remove();
 

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -232,8 +232,8 @@ export default Component.extend(ResizeAware, {
       .append('rect') // shape it as a rectangle
       .attr('x', x(0))
       .attr('y', y(0))
-      .attr('width', 235)
-      .attr('height', height + 4);
+      .attr('width', 236)
+      .attr('height', 200);
 
     moebars.enter()
       .append('rect')


### PR DESCRIPTION
This PR does two things:

- Adds a function `limitMax` which checks for whether a maximum x value is greater than `1`, and if so, sets the maximum to `1`
- Adds a new condition to `widthFunctionMOE`: if the percentage bar + the MOE bar extend past 100% percent on the x axis. If so, modify the MOE bar width to only extend to the remaining space between the end of the percentage bar and 100%. 

closes #685 