### PR TITLE
603: add track-page mixin to router for analytics

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,8 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
+import trackPage from './mixins/track-page';
 
-const Router = EmberRouter.extend({
+const Router = EmberRouter.extend(trackPage, {
   location: config.locationType,
   rootURL: config.rootURL,
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -112,9 +112,9 @@ module.exports = function(environment) {
         config: {
           id: 'UA-84250233-10',
           // Use `analytics_debug.js` in development
-          debug: environment === 'dev-debug-ga',
+          debug: environment === 'development-ga',
           // Use verbose tracing of GA events
-          trace: false,
+          trace: environment === 'development-ga',
           // Ensure development env hits aren't sent to GA
           sendHitTask: environment !== 'development',
         },


### PR DESCRIPTION
Google Analytics is registering page views and events on the console--this should mean that the problem is fixed on the Analytics profile as well. 