### PR TITLE
603: add track-page mixin to router to track pages for analytics

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,8 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
+import trackPage from './mixins/track-page';
 
-const Router = EmberRouter.extend({
+const Router = EmberRouter.extend(trackPage, {
   location: config.locationType,
   rootURL: config.rootURL,
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -110,7 +110,7 @@ module.exports = function(environment) {
         name: 'GoogleAnalytics',
         environments: ['production', 'development'],
         config: {
-          id: 'UA-84250233-10',
+          id: 'UA-135012626-1',
           // Use `analytics_debug.js` in development
           debug: environment === 'development-ga',
           // Use verbose tracing of GA events

--- a/config/environment.js
+++ b/config/environment.js
@@ -112,9 +112,9 @@ module.exports = function(environment) {
         config: {
           id: 'UA-84250233-10',
           // Use `analytics_debug.js` in development
-          debug: environment === 'dev-debug-ga',
+          debug: environment === 'development-ga',
           // Use verbose tracing of GA events
-          trace: false,
+          trace: environment === 'development-ga',
           // Ensure development env hits aren't sent to GA
           sendHitTask: environment !== 'development',
         },


### PR DESCRIPTION
Page views and events are registering in the console for Google Analytics, so this should work in the online profile as well. 