### PR TITLE
use-aliased-data

### DIFF
--- a/app/queries/summary-levels.js
+++ b/app/queries/summary-levels.js
@@ -9,7 +9,7 @@ export default {
       bctcb2010,
       bctcb2010 AS geoid,
       (ct2010::float / 100)::text || ' - ' || cb2010 as geolabel
-    FROM nyc_census_blocks_2010
+    FROM nyc_census_blocks
   `,
 
   tracts: (webmercator = true) => `
@@ -20,7 +20,7 @@ export default {
       boroct2010,
       ntacode,
       boroct2010 AS geoid
-    FROM nyc_census_tracts_2010
+    FROM nyc_census_tracts
   `,
 
   ntas: (webmercator = true) => `
@@ -30,7 +30,7 @@ export default {
       ntacode,
       ntacode as geolabel,
       ntacode AS geoid
-    FROM support_admin_ntaboundaries
+    FROM nta_boundaries
     WHERE ntaname NOT ILIKE 'park-cemetery-etc%25'
       AND ntaname != 'Airport'
   `,

--- a/app/sources/census-admin-boundaries.js
+++ b/app/sources/census-admin-boundaries.js
@@ -6,7 +6,7 @@ export default {
       id: 'neighborhood-tabulation-areas',
       sql: `
         SELECT a.the_geom_webmercator, ntaname, ntacode, ntacode AS geolabel, a.ntacode AS geoid
-        FROM support_admin_ntaboundaries a
+        FROM nta_boundaries a
         WHERE ntaname NOT ILIKE 'park-cemetery-etc%'
           AND ntaname != 'Airport'
       `,
@@ -14,7 +14,7 @@ export default {
 
     {
       id: 'neighborhood-tabulation-areas-centroids',
-      sql: 'SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM support_admin_ntaboundaries WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
+      sql: 'SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM nta_boundaries WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
     },
 
     {


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Related to https://github.com/NYCPlanning/labs-layers-api/pull/124