### PR TITLE
729: Update remaining references to 2016

### DIFF
--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -85,7 +85,7 @@ const choroplethConfigs = [
     group: 'Housing (ACS)',
     id: 'mdgr',
     label: 'Median Gross Rent',
-    tooltip: 'Median gross rent (in 2016 inflation-adjusted dollars)',
+    tooltip: 'Median gross rent (in 2017 inflation-adjusted dollars)',
     legendTitle: 'Median Gross Rent',
     stops: [1200, 1600, 2000, 2400],
   },

--- a/app/templates/profile/economic.hbs
+++ b/app/templates/profile/economic.hbs
@@ -120,7 +120,7 @@
       Income and Benefits
       {{fa-icon 'question-circle' transform='shrink-6 left-4 up-2'}}
       {{ember-tooltip
-        text="In 2016 inflation-adjusted dollars"
+        text="In 2017 inflation-adjusted dollars"
         side='bottom'
       }}
     </span>
@@ -154,7 +154,7 @@
       Earnings
       {{fa-icon 'question-circle' transform='shrink-6 left-4 up-2'}}
       {{ember-tooltip
-        text="In 2016 inflation-adjusted dollars"
+        text="In 2017 inflation-adjusted dollars"
         side='left'
       }}
     </span>

--- a/app/templates/profile/housing.hbs
+++ b/app/templates/profile/housing.hbs
@@ -160,7 +160,7 @@
       Value
       {{fa-icon 'question-circle' transform='shrink-6 left-4 up-2'}}
       {{ember-tooltip
-        text='In 2016 inflation-adjusted dollars'
+        text='In 2017 inflation-adjusted dollars'
         side='right'
       }}
     </span>
@@ -226,7 +226,7 @@
       Gross Rent
       {{fa-icon 'question-circle' transform='shrink-6 left-4 up-2'}}
       {{ember-tooltip
-        text='In 2016 inflation-adjusted dollars'
+        text='In 2017 inflation-adjusted dollars'
         side='right'
       }}
     </span>


### PR DESCRIPTION
Fixes up strings that previously said `2016 inflation-adjusted dollars` to say `2017 inflation-adjusted dollars` since data has been updated. 