### PR TITLE
Change the bins for popu181 choropleth map

### DIFF
--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -20,7 +20,7 @@ const choroplethConfigs = [
     label: 'Under 18 Years',
     tooltip: 'Population under 18 years',
     legendTitle: 'Population under 18 years',
-    stops: [8000, 12000, 15000, 20000],
+    stops: [8000, 10000, 15000, 20000],
   },
   {
     group: 'Demographic (ACS)',


### PR DESCRIPTION
Updates the binning for popu181 in the choropleth map.

See https://github.com/NYCPlanning/labs-factfinder-api/issues/82

Relevant bullet:

> Thematic Maps: Change categories for 'Under 18 Years':
> 20,000 or more
> 15,000 to 19,999
> 10,000 to 14,999
> 8,000 to 9,999
> Under 8,000

In this PR, I change the "stops" property, which is a MapboxGL Style Specification feature. The request from Erica was to change how things were binned (i think this comes from the census bureau).

