### PR TITLE
Disable the default modal

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -22,5 +22,10 @@ as |banner|
 </div>
 
 <div id="reveal-modal-container">
-  {{default-modal}}
+  {{!--
+    The default-modal is open/visible when the app is loaded
+    Uncomment the following component to enable the modal
+    Change its content in ./components/default-modal.hbs
+  --}}
+  {{!-- {{default-modal}} --}}
 </div>


### PR DESCRIPTION
This PR simply comments out the `{{default-modal}}` component in the application template. (Left it in there for future use.)