### PR TITLE
3164 Set up stub data explorer route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -8,6 +8,7 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () { // eslint-disable-line
+  // TODO: Deprecate, migrate to /explorer
   this.route('profile', { path: 'profile/:id' }, function () {
     this.route('census');
     this.route('demographic');
@@ -15,6 +16,7 @@ Router.map(function () { // eslint-disable-line
     this.route('economic');
     this.route('housing');
   });
+  this.route('explorer');
   this.route('about');
   this.route('features');
   this.route('data');

--- a/app/routes/explorer.js
+++ b/app/routes/explorer.js
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+
+});

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -8,6 +8,7 @@ const { SupportServiceHost } = Environment;
 const SELECTION_API_URL = id => `${SupportServiceHost}/selection/${id}`;
 
 /**
+ * TODO: Deprecate. Migrate to 'explorer' route.
  * The Profile Route is responsible for fetching information for a given selection ID.
  * It also defines query parameters for the controller, which are used to manage
  * the state of the profile view.

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -1,0 +1,8 @@
+<div class="overflow-y-grid grid-padding-x" id="explorer-wrapper">
+  <div class="cell shrink">
+    Data Explorer
+  </div>
+  <div class="cell auto" id="explorer-content">
+    {{outlet}}
+  </div>
+</div>


### PR DESCRIPTION
Fixes AB#3164

PR introduces basic route (/explorer) js and templates for the Data Explorer.

Although it is similar to the previous /profile route, since the user stories/wireframe brand this feature as "Data Explorer", I thought it would be good to migrate the code to reflect this as well.

Thinking we can keep the /profile route code available while we build out, and slowly extract and migrate necessary code over to the /explorer route.