### PR TITLE
3166 Update app header links, styling

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationController extends Controller {
+  @service router;
+}

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -150,6 +150,10 @@ button {
 }
 
 
+.active-route {
+  color: $primary-color !important;
+}
+
 //
 // Profiles
 // --------------------------------------------------

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,11 +8,24 @@ as |banner|
 {{/banner.title}}
 {{#banner.nav}}
   <ul class="vertical large-horizontal menu">
-    <li>{{link-to 'About' 'about'}}</li>
-    <li>{{link-to 'Tutorial' 'tutorial'}}</li>
-    <li>{{link-to 'Features' 'features'}}</li>
-    <li>{{link-to 'Data' 'data'}}</li>
-    <li class="external-nav-item"><a href="mailto:pff_dl@planning.nyc.gov?subject=Population%20FactFinder%20Feedback">{{fa-icon icon="envelope" prefix="far" transform='grow-4'}}</a></li>
+    <li>
+      {{#link-to
+        'index'
+        class=(if (eq this.router.currentRouteName "index") "active-route")
+      }}
+        {{fa-icon "map" prefix="fa" transform='grow-4'}}
+        Custom Map Study
+      {{/link-to}}
+    </li>
+    <li>
+      {{#link-to
+        'explorer'
+        class=(if (eq this.router.currentRouteName "explorer") "active-route")
+      }}
+        {{fa-icon "search" prefix="fa" transform='grow-4'}}
+        Data Explorer
+      {{/link-to}}
+    </li>
   </ul>
 {{/banner.nav}}
 {{/labs-ui/site-header}}


### PR DESCRIPTION
Fixes AB#3166 

Update header to match wireframe:
![image](https://user-images.githubusercontent.com/3311663/120809241-dd245e80-c517-11eb-9f66-f8ee3a6e505b.png)

Links are orange when user is on respective route
