### PR TITLE
Apply codemod: No Implicit “This”

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -9,7 +9,7 @@
         'index'
         class=(if (eq this.router.currentRouteName "index") "active-route")
       }}
-        {{fa-icon "map" prefix="fa" transform='grow-4'}}
+        {{fa-icon icon="map" prefix="fa" transform='grow-4'}}
         Custom Map Study
       {{/link-to}}
     </li>
@@ -18,7 +18,7 @@
         'explorer'
         class=(if (eq this.router.currentRouteName "explorer") "active-route")
       }}
-        {{fa-icon "search" prefix="fa" transform='grow-4'}}
+        {{fa-icon icon="search" prefix="fa" transform='grow-4'}}
         Data Explorer
       {{/link-to}}
     </li>

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -1,4 +1,4 @@
-{{#unless (or @rowConfig.divider noPriorData)}}
+{{#unless (or @rowConfig.divider this.noPriorData)}}
   <td class='title-column' {{action 'showData'}}>
     <span>
       {{@rowConfig.title}}
@@ -91,7 +91,7 @@
     </td>
   {{/if}}
 {{else}}
-  {{#if noPriorData}}
+  {{#if this.noPriorData}}
     {{!-- if 2006-2010 sum is null, just return empty cells --}}
     <td class='title-column' {{action 'showData'}}>
       <span>

--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,4 +1,4 @@
-<RevealModal @open={{open}} @closeModal={{action 'toggleModal'}}>
+<RevealModal @open={{this.open}} @closeModal={{action 'toggleModal'}}>
   <h1 class="header-xlarge">
     A note to our users about upcoming changes:
   </h1>

--- a/app/templates/components/horizontal-bar.hbs
+++ b/app/templates/components/horizontal-bar.hbs
@@ -1,4 +1,4 @@
-{{#if (is-pending data)}}
+{{#if (is-pending this.data)}}
   <div class="spinner-wrapper loading">
     <div class="spinner">
       <div class="bounce1"></div>

--- a/app/templates/components/labs-map.hbs
+++ b/app/templates/components/labs-map.hbs
@@ -1,25 +1,25 @@
-{{#if glSupported}}
-  {{#if map}}
+{{#if this.glSupported}}
+  {{#if this.map}}
 
     {{mapbox-gl-layer
-      map=map
-      layer=highlightedFeatureLayer}}
+      map=this.map
+      layer=this.highlightedFeatureLayer}}
 
     {{yield (hash
-      call=(component 'mapbox-gl-call' obj=map)
-      control=(component 'mapbox-gl-control' map=map)
-      image=(component 'mapbox-gl-image' map=map)
-      layer=(component 'mapbox-gl-layer' map=map)
-      marker=(component 'mapbox-gl-marker' map=map)
-      on=(component 'mapbox-gl-on' eventSource=map)
-      popup=(component 'mapbox-gl-popup' map=map)
-      source=(component 'mapbox-gl-source' map=map)
-      labs-layers=(component 'labs-layers' map=map layerGroups=layerGroups)
+      call=(component 'mapbox-gl-call' obj=this.map)
+      control=(component 'mapbox-gl-control' map=this.map)
+      image=(component 'mapbox-gl-image' map=this.map)
+      layer=(component 'mapbox-gl-layer' map=this.map)
+      marker=(component 'mapbox-gl-marker' map=this.map)
+      on=(component 'mapbox-gl-on' eventSource=this.map)
+      popup=(component 'mapbox-gl-popup' map=this.map)
+      source=(component 'mapbox-gl-source' map=this.map)
+      labs-layers=(component 'labs-layers' map=this.map layerGroups=this.layerGroups)
       layer-group=(component 'layer-group'
         parentComponent=this
         map=(hash
-          layer=(component 'mapbox-gl-layer' map=map)
-          source=(component 'mapbox-gl-source' map=map)
+          layer=(component 'mapbox-gl-layer' map=this.map)
+          source=(component 'mapbox-gl-source' map=this.map)
         )
       )
     )

--- a/app/templates/components/labs-ui/icon-tooltip.hbs
+++ b/app/templates/components/labs-ui/icon-tooltip.hbs
@@ -1,2 +1,2 @@
-{{~fa-icon icon=icon transform=transform fixedWidth=fixedWidth~}}
-{{ember-tooltip text=tip side=side}}
+{{~fa-icon icon=this.icon transform=this.transform fixedWidth=this.fixedWidth~}}
+{{ember-tooltip text=this.tip side=this.side}}

--- a/app/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/app/templates/components/labs-ui/layer-group-toggle.hbs
@@ -1,35 +1,35 @@
-<div class="layer-group-toggle-header layer-{{dasherize label}}">
+<div class="layer-group-toggle-header layer-{{dasherize this.label}}">
   <div class="grid-x">
     <div class="cell auto ">
       <div class="switch tiny float-left">
-        <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
+        <input class="switch-input" type="checkbox" checked={{if this.active 'checked'}}>
         <label {{action 'toggle'}} class="switch-paddle">
           <span class="show-for-sr">Toggle Layer Group</span>
         </label>
       </div>
       <span {{action 'toggle' preventDefault=false}} class="layer-group-toggle-label" role="button">
-        {{label}}
-        {{#if active}}
-          {{#if icon}}
-            {{labs-ui/legend-icon icon=icon}}
+        {{this.label}}
+        {{#if this.active}}
+          {{#if this.icon}}
+            {{labs-ui/legend-icon icon=this.icon}}
           {{/if}}
         {{/if}}
       </span>
     </div>
     <div class="cell shrink layer-group-toggle-icons">
-      {{#if (and activeTooltip active)}}
-        {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left' fixedWith=true}}
+      {{#if (and this.activeTooltip this.active)}}
+        {{labs-ui/icon-tooltip tip=this.activeTooltip icon=this.activeTooltipIcon side='left' fixedWith=true}}
       {{/if}}
-      {{#if infoLink}}
-        <a href="{{infoLink}}" target="_blank" class="info-link" rel="noopener noreferrer">{{fa-icon infoLinkIcon fixedWidth=true}}</a>
+      {{#if this.infoLink}}
+        <a href="{{this.infoLink}}" target="_blank" class="info-link" rel="noopener noreferrer">{{fa-icon this.infoLinkIcon fixedWidth=true}}</a>
       {{/if}}
-      {{#if tooltip}}
-        {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left' fixedWidth=true}}
+      {{#if this.tooltip}}
+        {{labs-ui/icon-tooltip tip=this.tooltip icon=this.tooltipIcon side='left' fixedWidth=true}}
       {{/if}}
     </div>
   </div>
 </div>
-{{#if active}}
+{{#if this.active}}
   <div class="layer-group-toggle-content">
     {{yield}}
   </div>

--- a/app/templates/components/labs-ui/site-header.hbs
+++ b/app/templates/components/labs-ui/site-header.hbs
@@ -2,18 +2,18 @@
   <div href="https://planninglabs.nyc/" class="labs-beta-notice hide-for-print"></div>
   <div class="grid-x grid-padding-x">
 
-    <div {{action (mut closed) true preventDefault=false}} class="branding cell {{if responsiveNav (concat responsiveSize '-auto shrink') 'auto'}}">
+    <div {{action (mut this.closed) true preventDefault=false}} class="branding cell {{if this.responsiveNav (concat this.responsiveSize '-auto shrink') 'auto'}}">
       <a class="dcp-link" href="http://www1.nyc.gov/site/planning/index.page"><img class="dcp-logo" src="https://raw.githubusercontent.com/NYCPlanning/logo/master/dcp_logo_772.png" alt="NYC Planning"></a>
       {{yield (hash title = (component 'labs-ui/site-title'))}}
     </div>
 
-    {{#if responsiveNav}}
-      <div class="cell auto hide-for-{{responsiveSize}} text-right">
-        <button class="responsive-nav-toggler hide-for-print" type="button" {{action (mut closed) (not closed)}}>Menu</button>
+    {{#if this.responsiveNav}}
+      <div class="cell auto hide-for-{{this.responsiveSize}} text-right">
+        <button class="responsive-nav-toggler hide-for-print" type="button" {{action (mut this.closed) (not this.closed)}}>Menu</button>
       </div>
     {{/if}}
 
-    <nav {{action (mut closed) (not closed) preventDefault=false}} class="cell {{if responsiveNav (concat responsiveSize '-shrink responsive') 'shrink'}} {{if (and responsiveNav closed) (concat 'show-for-' responsiveSize)}} hide-for-print">
+    <nav {{action (mut this.closed) (not this.closed) preventDefault=false}} class="cell {{if this.responsiveNav (concat this.responsiveSize '-shrink responsive') 'shrink'}} {{if (and this.responsiveNav this.closed) (concat 'show-for-' this.responsiveSize)}} hide-for-print">
       {{yield (hash nav = (component 'labs-ui/site-nav'))}}
     </nav>
 

--- a/app/templates/components/layer-group.hbs
+++ b/app/templates/components/layer-group.hbs
@@ -1,9 +1,9 @@
-{{#if visible}}
-  {{#each config.layers as |layerConfig|}}
+{{#if this.visible}}
+  {{#each this.config.layers as |layerConfig|}}
     {{map.layer
       layer=layerConfig.layer
-      didUpdateLayers=didUpdateLayers
-      before=before}}
+      didUpdateLayers=this.didUpdateLayers
+      before=this.before}}
   {{/each}}
 {{/if}}
 
@@ -12,28 +12,34 @@
     timeline-control=
       (component 'layer-control-timeline' layer=
         (hash
-          visible=visible
+          visible=this.visible
         )
-        qps=qps
+        qps=this.qps
       )
 
     multi-select-control=
       (component 'layer-multi-select-control' layer=
         (hash
-          visible=visible
+          visible=this.visible
         )
-        qps=qps
+        qps=this.qps
       )
+
     tooltip=
       (component 'layer-tooltip' layer=
         (hash
-          visible=visible
+          visible=this.visible
         )
       )
-    visible=visible
+
+    visible=this.visible
+
     updateSql=(action 'updateSql')
+
     updatePaintFor=(action 'updatePaintFor')
-    isPending=configWithTemplate.isPending
+
+    isPending=this.configWithTemplate.isPending
+
     toggleVisibility=(action 'toggleVisibility')
   )
 }}

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -1,8 +1,8 @@
-{{#if layer}}
+{{#if this.layer}}
   <div class="layer-menu-item-header" {{action 'toggleVisibility'}}>
 
-    {{#if (or warning this.titleTooltip)}}
-      {{#if warning}}
+    {{#if (or this.warning this.titleTooltip)}}
+      {{#if this.warning}}
         <span class="float-right gold">
           {{labs-ui/icon-tooltip
             icon='exclamation-triangle'
@@ -22,18 +22,18 @@
       {{/if}}
     {{/if}}
 
-    {{switch-toggle checked=visible}}
+    {{switch-toggle checked=this.visible}}
 
     {{this.title}}
 
-    {{#if visible}}
+    {{#if this.visible}}
 
-      {{#with legendIcon as |legendIcon|}}
+      {{#with this.legendIcon as |legendIcon|}}
         {{#if (eq legendIcon 'admin-line')}}
-          <span class="layer-group-legend" style="border-color:{{legendColor}};"></span>
+          <span class="layer-group-legend" style="border-color:{{this.legendColor}};"></span>
         {{/if}}
         {{#if (eq legendIcon 'polygon')}}
-          <span class="icon polygon legend-icon" style="background-color:{{legendColor}};"></span>
+          <span class="icon polygon legend-icon" style="background-color:{{this.legendColor}};"></span>
         {{/if}}
       {{/with}}
     {{/if}}
@@ -41,10 +41,10 @@
 
   </div>
 
-  {{#if visible}}
+  {{#if this.visible}}
     <div class="layer-menu-item-content">
       {{~yield (hash
-        layer=layer
+        layer=this.layer
         updateSql=(action 'updateSql')
         updatePaintFor=(action 'updatePaintFor')
         )~}}

--- a/app/templates/components/lookup-layer-group.hbs
+++ b/app/templates/components/lookup-layer-group.hbs
@@ -1,4 +1,4 @@
 {{yield (hash
   model=this.model
-  layer=layer
+  layer=this.layer
 )}}

--- a/app/templates/components/map-search.hbs
+++ b/app/templates/components/map-search.hbs
@@ -1,20 +1,20 @@
 {{input type='text'
   placeholder='Search...'
   class='map-search-input'
-  value=searchTerms
+  value=this.searchTerms
   focus-in=(action 'handleFocusIn')
   focus-out=(action 'handleFocusOut')}}
 
-{{#if searchTerms}}
+{{#if this.searchTerms}}
   <button class="close-button" aria-label="Clear Search" type="button" {{action 'clear'}}>
     <span aria-hidden="true">&times;</span>
   </button>
 {{else}}
   <span class="search-icon">{{fa-icon icon="search"}}</span>
 {{/if}}
-<ul class="search-results no-bullet{{if resultsCount ' has-results'}}{{if focused ' focused'}}">
-  {{#if (is-fulfilled results)}}
-  {{#each-in (group-by "type" results.value) as |type rows|}}
+<ul class="search-results no-bullet{{if this.resultsCount ' has-results'}}{{if this.focused ' focused'}}">
+  {{#if (is-fulfilled this.results)}}
+  {{#each-in (group-by "type" this.results.value) as |type rows|}}
     <li>
       {{#if (eq type 'block')}}
         <h4 class="header-small results-header">2010 Census Blocks</h4>
@@ -29,7 +29,7 @@
       {{/if}}
     </li>
     {{#each rows as |result|}}
-      <li class="result {{if (eq selected result.id) 'highlighted-result'}}" {{action 'goTo' result}}>
+      <li class="result {{if (eq this.selected result.id) 'highlighted-result'}}" {{action 'goTo' result}}>
         {{#if (eq type 'block')}}
           <span class="icon polygon small"></span>
         {{else if (eq type 'tract')}}
@@ -48,11 +48,11 @@
 {{/if}}
 
 </ul>
-{{#if (is-pending results)}}
+{{#if (is-pending this.results)}}
   <div class="search-results--loading">Loading...</div>
 {{/if}}
 
-{{#if (and searchTerms (not resultsCount) (is-fulfilled results))}}
+{{#if (and this.searchTerms (not this.resultsCount) (is-fulfilled this.results))}}
   <div class="search-results--loading">No Results Found</div>
 {{/if}}
 {{yield}}

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -57,8 +57,8 @@
     <p><a {{action "toggleAdvancedOptions"}} class="text-small">{{fa-icon icon='sliders-h'}}&nbsp;Advanced Options </a></p>
   </div>
 
-  <div class="advanced-options {{unless advanced 'closed'}}">
-    {{#unless closed}}
+  <div class="advanced-options {{unless this.advanced 'closed'}}">
+    {{#unless this.closed}}
 
       <div class="selection-helpers">
       </div>
@@ -68,7 +68,7 @@
           <div class="grid-x">
             <div class="cell small-8">
               <ul class="radio-buttons-list">
-                {{#each-in (group-by "group" choroplethConfigs) as |group configs|}}
+                {{#each-in (group-by "group" this.choroplethConfigs) as |group configs|}}
                   <h5 style="margin:0.5rem 0 0;font-size:1em;">{{group}}</h5>
                   <ul class="no-bullet">
                     {{#each configs as |config|}}
@@ -76,11 +76,11 @@
                         action (
                           queue
                             (action 'setChoroplethMode' config.id)
-                            (action item.updatePaintFor 'choropleth-nta-fill' choroplethPaintFill)
-                            (action item.updatePaintFor 'choropleth-nta-line' choroplethPaintLine)
+                            (action item.updatePaintFor 'choropleth-nta-fill' this.choroplethPaintFill)
+                            (action item.updatePaintFor 'choropleth-nta-line' this.choroplethPaintLine)
                         )
                       }}>
-                        {{#if (eq choroplethMode config.id)}}
+                        {{#if (eq this.choroplethMode config.id)}}
                           {{fa-icon icon='dot-circle' prefix='far'}}
                         {{else}}
                           {{fa-icon icon='circle' prefix='far'}}
@@ -95,8 +95,8 @@
             </div>
             <div class="cell small-4">
               <div class="legend">
-                <div class="legend-title">{{legendTitle}}</div>
-                {{#each stops as |stop|}}
+                <div class="legend-title">{{this.legendTitle}}</div>
+                {{#each this.stops as |stop|}}
                   <div class="legend-item">
                     <span class="legend-color" style={{sanitize-style (hash color=stop.color)}}>{{fa-icon icon='square'}}</span>
                     {{stop.label}}
@@ -149,5 +149,5 @@
   </div>
 
 {{else}}
-  {{component mode}}
+  {{component this.mode}}
 {{/if}}

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -5,16 +5,16 @@
         <li class="dropdown">
           <a href="#" class="dropbtn dropbtn-left">{{fa-icon icon='edit'}} &nbsp;Draw</a>
           <div class="dropsizer">
-            <div class="dropdown-content dropdown-content-left {{if (or (eq drawMode 'radius') (eq drawMode 'polygon')) 'active'}}">
+            <div class="dropdown-content dropdown-content-left {{if (or (eq this.drawMode 'radius') (eq this.drawMode 'polygon')) 'active'}}">
               {{#ember-tooltip delay=200}}
                 <span class="text-tiny nowrap">Create selection using drawing tool</span>
               {{/ember-tooltip}}
               
-              <a href="#" class="{{if (eq drawMode 'polygon') 'active'}} {{if (eq drawMode 'radius') 'hide-for-large'}}" {{action "handleDrawButtonClick" 'polygon'}}>
+              <a href="#" class="{{if (eq this.drawMode 'polygon') 'active'}} {{if (eq this.drawMode 'radius') 'hide-for-large'}}" {{action "handleDrawButtonClick" 'polygon'}}>
                 {{fa-icon icon='object-group' prefix='far'}}
                 <span class="hide-for-medium">Draw</span> Polygon
               </a>
-              <a href="#" class="{{if (eq drawMode 'radius') 'active'}} {{if (eq drawMode 'polygon') 'hide-for-large'}}" {{action "handleDrawButtonClick" 'radius'}}>
+              <a href="#" class="{{if (eq this.drawMode 'radius') 'active'}} {{if (eq this.drawMode 'polygon') 'hide-for-large'}}" {{action "handleDrawButtonClick" 'radius'}}>
                 {{fa-icon icon='dot-circle' prefix='far'}}
                 <span class="hide-for-medium">Draw</span> Radius
               </a>
@@ -81,8 +81,8 @@
 {{#if (eq this.mode 'direct-select')}}
 
 
-  <div class="advanced-options {{unless advanced 'closed'}}" style="color:black">
-    {{#unless closed}}
+  <div class="advanced-options {{unless this.advanced 'closed'}}" style="color:black">
+    {{#unless this.closed}}
 
       <div class="selection-helpers">
       </div>
@@ -92,7 +92,7 @@
           <div class="grid-x">
             <div class="cell small-8">
               <ul class="radio-buttons-list">
-                {{#each-in (group-by "group" choroplethConfigs) as |group configs|}}
+                {{#each-in (group-by "group" this.choroplethConfigs) as |group configs|}}
                   <h5 style="margin:0.5rem 0 0;font-size:1em;">{{group}}</h5>
                   <ul class="no-bullet">
                     {{#each configs as |config|}}
@@ -100,11 +100,11 @@
                         action (
                           queue
                             (action 'setChoroplethMode' config.id)
-                            (action item.updatePaintFor 'choropleth-nta-fill' choroplethPaintFill)
-                            (action item.updatePaintFor 'choropleth-nta-line' choroplethPaintLine)
+                            (action item.updatePaintFor 'choropleth-nta-fill' this.choroplethPaintFill)
+                            (action item.updatePaintFor 'choropleth-nta-line' this.choroplethPaintLine)
                         )
                       }}>
-                        {{#if (eq choroplethMode config.id)}}
+                        {{#if (eq this.choroplethMode config.id)}}
                           {{fa-icon icon='dot-circle' prefix='far'}}
                         {{else}}
                           {{fa-icon icon='circle' prefix='far'}}
@@ -119,8 +119,8 @@
             </div>
             <div class="cell small-4">
               <div class="legend">
-                <div class="legend-title">{{legendTitle}}</div>
-                {{#each stops as |stop|}}
+                <div class="legend-title">{{this.legendTitle}}</div>
+                {{#each this.stops as |stop|}}
                   <div class="legend-item">
                     <span class="legend-color" style={{sanitize-style (hash color=stop.color)}}>{{fa-icon icon='square'}}</span>
                     {{stop.label}}
@@ -184,5 +184,5 @@
   </div>
 
 {{else}}
-  {{component mode}}
+  {{component this.mode}}
 {{/if}}

--- a/app/templates/components/reveal-modal.hbs
+++ b/app/templates/components/reveal-modal.hbs
@@ -1,4 +1,4 @@
-{{#if open}}
+{{#if this.open}}
   <div class="reveal-overlay" style="display:block;">
     <div class="reveal-overlay-target" {{action this.closeModal}}></div>
     <div

--- a/app/templates/components/switch-toggle.hbs
+++ b/app/templates/components/switch-toggle.hbs
@@ -1,5 +1,5 @@
 <div class="switch tiny float-left">
-  <input class="switch-input" type="checkbox" name="exampleSwitch" checked={{checked}}>
+  <input class="switch-input" type="checkbox" name="exampleSwitch" checked={{this.checked}}>
   <label class="switch-paddle" for="exampleSwitch">
     <span class="show-for-sr">Toggle Layer Group</span>
   </label>

--- a/app/templates/components/tooltip-renderer.hbs
+++ b/app/templates/components/tooltip-renderer.hbs
@@ -1,1 +1,1 @@
-{{renderedText}}
+{{this.renderedText}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -29,10 +29,16 @@
 
  {{!--  TURN THIS OFF TO GET RID OF THE MAP  --}}
 <div class="map-container">
-  <LabsMap @id="map" @sources={{sources}} @initOptions={{hash zoom=zoom
-                      center=center
-                      hash=true}} @mapLoaded={{action 'handleMapLoad'}} as |map|>
-
+  <LabsMap 
+    @id="map"
+    @sources={{this.sources}}
+    @initOptions={{hash
+      zoom=this.zoom
+      center=this.center
+      hash=true
+    }}
+    @mapLoaded={{action 'handleMapLoad'}} as |map|
+  >
     <map.labs-layers @onLayerClick={{action 'handleClick'}} @layerGroups={{this.model.layerGroups}} as |layers|>
       <layers.tooltip as |tooltip|>
         {{tooltip-renderer
@@ -140,7 +146,7 @@
   </LabsMap>
 </div>
 
-<MapUtilityBox
+{{!-- <MapUtilityBox
   @lastreport={{lastreport}}
   @mode={{this.mode}}
   @drawMode={{drawMode}}
@@ -156,6 +162,6 @@
     addRemoveLinks=true
     autoProcessQueue=false
   }}
-</MapUtilityBox>
+</MapUtilityBox> --}}
 
 {{outlet}}


### PR DESCRIPTION
Changes implicit references to component class properties to `this.` prefixed refs.

Ran this coded and it affects only components: https://github.com/ember-codemods/ember-no-implicit-this-codemod