### PR TITLE
3173 Basic Topic Select Dropdown UI

### DIFF
--- a/app/components/explorer/topic-select-dropdown.js
+++ b/app/components/explorer/topic-select-dropdown.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default class TopicSelectDropdownComponent extends Component {
+  open = false;
+}

--- a/app/components/ui/nestable-list-item.js
+++ b/app/components/ui/nestable-list-item.js
@@ -1,0 +1,13 @@
+import Component from '@ember/component';
+
+export default class NestableListItemComponent extends Component {
+  open = false;
+
+  get hasChildren() {
+    if (this.item && this.item.children) {
+      return this.item.children.length > 0;
+    }
+
+    return false;
+  }
+}

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -10,4 +10,75 @@ export default class ExplorerController extends Controller {
   disaggregate = false;
 
   compareTo = null;
+
+  topics = [
+    {
+      label: 'Demographic',
+      selected: true,
+      type: 'topic',
+      children: [
+        {
+          label: 'Demo 1',
+          selected: true,
+          type: 'subtopic',
+        },
+        {
+          label: 'Demo 2',
+          selected: true,
+          type: 'subtopic',
+        }
+      ],
+    },
+    {
+      label: 'Social',
+      selected: false,
+      type: 'topic',
+      children: [
+        {
+          label: 'Social 1',
+          selected: false,
+          type: 'subtopic',
+        },
+        {
+          label: 'Social 2',
+          selected: false,
+          type: 'subtopic',
+        }
+      ],
+    },
+    {
+      label: 'Economic',
+      selected: false,
+      type: 'topic',
+      children: [
+        {
+          label: 'Econ 1',
+          selected: false,
+          type: 'subtopic',
+        },
+        {
+          label: 'Econ 2',
+          selected: false,
+          type: 'subtopic',
+        }
+      ],
+    },
+    {
+      label: 'Housing',
+      selected: false,
+      type: 'topic',
+      children: [
+        {
+          label: 'Housing Stat 1',
+          selected: false,
+          type: 'subtopic',
+        },
+        {
+          label: 'Housing Stat 2',
+          selected: false,
+          type: 'subtopic',
+        }
+      ],
+    },
+  ]
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -50,3 +50,7 @@ $table-border: 1px solid $silver;
 @import 'modules/_m-spinner';
 
 @import "ember-power-select";
+
+// Component styles
+@import 'modules/components/explorer/topic-select-dropdown';
+@import 'modules/components/ui/nestable-list-item';

--- a/app/styles/modules/components/explorer/topic-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/topic-select-dropdown.scss
@@ -1,0 +1,35 @@
+// --------------------------------------------------
+// Module: Topic Select Dropdown
+// --------------------------------------------------
+
+.topic-select-toggle {
+  width: 250px !important;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-radius: 5px;
+}
+
+.topic-count {
+  color: $dark-gray;
+}
+
+.topic-menu {
+  position: absolute;
+  top: 100%;
+  margin-top: -15px;
+  right: rem-calc(-6);
+  bottom: auto;
+  left: rem-calc(0);
+  background-color: $white;
+  padding: rem-calc(6);
+  box-shadow: 0 4px 0 rgba(0,0,0,0.1);
+  width: 250px !important;
+  color: $dark-gray;
+  border: 1px solid rgb(223, 225, 229);
+  border-radius: 0 0px 5px 5px;
+  text-align: left !important;
+}
+
+.subtopic-list-item {
+  padding-left: 10px;
+}

--- a/app/styles/modules/components/ui/nestable-list-item.scss
+++ b/app/styles/modules/components/ui/nestable-list-item.scss
@@ -1,0 +1,11 @@
+.nestable-list-item {
+  &.clickable {
+    &:hover {
+      cursor: pointer;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;  
+    }
+  }
+}

--- a/app/templates/components/explorer/topic-select-dropdown.hbs
+++ b/app/templates/components/explorer/topic-select-dropdown.hbs
@@ -1,0 +1,27 @@
+<button
+  class="topic-select-toggle button gray expanded no-margin"
+  role="button"
+  {{action (mut this.open) (not this.open)}}
+>
+  <div class="grid-x full">
+    <div class="cell small-11">
+      Select Topics:
+      <span class="topic-count">
+        4 Selected
+      </span>
+    </div>
+    <div class="cell auto">
+      {{fa-icon icon=(if this.open 'caret-up' 'caret-down')}}
+    </div>
+  </div>
+</button>
+
+{{#if this.open}}
+  <div class="topic-menu">
+    {{#each @topics as |topic|}}
+      <Ui::NestableListItem
+        @item={{topic}}
+      />
+    {{/each}}
+  </div>
+{{/if}}

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -1,0 +1,9 @@
+<div class="grid-x">
+  <div class="cell small-12">
+    <Explorer::TopicSelectDropdown
+      @topics={{@topics}}
+    />
+  </div>
+  <div class="cell auto">
+  </div>
+</div>

--- a/app/templates/components/ui/nestable-list-item.hbs
+++ b/app/templates/components/ui/nestable-list-item.hbs
@@ -1,0 +1,40 @@
+<div
+  class="nestable-list-item grid-x {{if this.hasChildren 'clickable'}} {{@item.type}}-list-item"
+>
+  <div class="cell small-1"
+    {{action (mut @item.selected) (not @item.selected)}}
+  >
+    <span class="dcp-orange">
+      {{#if @item.selected}}
+        {{fa-icon icon='check-square' prefix='far'}}
+      {{else}}
+        {{fa-icon icon='square' prefix='far'}}
+      {{/if}}
+    </span>
+  </div>
+
+  <div
+    class="cell auto"
+    {{action (mut this.open) (not this.open)}}
+  >
+    {{@item.label}}
+  </div>
+
+  <div class="cell small-1"
+    {{action (mut this.open) (not this.open)}}
+  >
+    {{#if this.hasChildren}}
+      {{fa-icon icon=(if this.open 'caret-up' 'caret-down')}}
+    {{/if}}
+  </div>
+
+  {{#if this.open}}
+    <div class="cell small-12">
+      {{#each @item.children as |child|}}
+        <Ui::NestableListItem
+          @item={{child}}
+        />
+      {{/each}}
+    </div>
+  {{/if}}
+</div>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -1,11 +1,10 @@
 <OrangeBar>
-  <OrangeBarDataExplorer />
+  <OrangeBarDataExplorer
+    @topics={{this.topics}}
+  />
 </OrangeBar>
 
 <div class="overflow-y-grid grid-padding-x" id="explorer-wrapper">
-  <div class="cell shrink">
-    Data Explorer
-  </div>
   <div class="cell auto" id="explorer-content">
     {{outlet}}
   </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -76,6 +76,7 @@ module.exports = function (environment) {
           'arrow-right',
           'arrow-up',
           'caret-down',
+          'caret-up',
           'download',
           'edit',
           'exclamation-triangle',


### PR DESCRIPTION
### Summary
This PR sets up the styled topic selection dropdown UI. Upcoming PRs will handle modifying topic selection state using actions.

#### Tasks/Bug Numbers
Fixes [AB#3173](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3173)

### Technical Explanation

PR sets up new components:
  - topic-select-dropdown  -- the component representing the dropdown
  - nestable-list-item -- component representing each expandable/collapsible topic in the dropdown. It can be recursively nested, and is data driven. 

PR sets up the new `app/components/ui` folder to hold general (non-labs ui) UI components, not specific to any page in Factfinder. 

PR also sets up new hierarchy in the `styles/modules/` folder.:
  - `styles/modules/components` -- holds scss files associted to components. Within this folder, the hierarchy should match that of the hierarchy of `app/components`  and `app/templates/components` 
  
    For example `styles/modules/components/ui` corresponds to styles for components in `app/components/ui` 
    


