### PR TITLE
3173 Modify selected topic state

### DIFF
--- a/app/components/explorer/topic-select-dropdown.js
+++ b/app/components/explorer/topic-select-dropdown.js
@@ -1,5 +1,54 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
+
+/**
+  * @param { Object[] } topics - array of Topic objects. See controller for an exampl
+*/
 export default class TopicSelectDropdownComponent extends Component {
-  open = false;
+  @tracked open = false;
+
+  @action toggleOpen() {
+    this.open = !this.open;
+  }
+
+  toggleChildren = (children, selectedValue) => {
+    return children.map(child => {
+      return {
+        ...child,
+        selected: selectedValue,
+        children: this.toggleChildren(child.children, selectedValue),
+      }
+    });
+  }
+
+  toggleTopicInList = (topics, itemId) => {
+    return topics.map((topic) => {
+      if (topic.id === itemId) {
+        const newSelectedValue = !topic.selected;
+
+        return {
+          ...topic,
+          selected: newSelectedValue,
+          children: this.toggleChildren(topic.children, newSelectedValue),
+        };
+      }
+
+      if (topic.children && topic.children.length > 0) {
+        return {
+          ...topic,
+          children: this.toggleTopicInList(topic.children, itemId),
+        }
+      }
+
+      return topic;
+    });
+  }
+  
+  @action onListItemToggle(itemId) {
+    const newNestedListItems = this.toggleTopicInList(this.args.topics, itemId);
+
+    this.args.setTopics(newNestedListItems);
+  }
 }

--- a/app/components/ui/nestable-list-item.js
+++ b/app/components/ui/nestable-list-item.js
@@ -1,11 +1,17 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class NestableListItemComponent extends Component {
-  open = false;
+  @tracked open = false;
+
+  @action toggleOpen() {
+    this.open = !this.open;
+  }
 
   get hasChildren() {
-    if (this.item && this.item.children) {
-      return this.item.children.length > 0;
+    if (this.args.item && this.args.item.children) {
+      return this.args.item.children.length > 0;
     }
 
     return false;

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -1,4 +1,6 @@
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class ExplorerController extends Controller {
   showChart = true;
@@ -11,74 +13,98 @@ export default class ExplorerController extends Controller {
 
   compareTo = null;
 
-  topics = [
+  @tracked topics = [
     {
+      id: '123',
       label: 'Demographic',
       selected: true,
       type: 'topic',
       children: [
         {
+          id: '124',
           label: 'Demo 1',
           selected: true,
           type: 'subtopic',
+          children: [],
         },
         {
+          id: '125',
           label: 'Demo 2',
           selected: true,
           type: 'subtopic',
+          children: [],
         }
       ],
     },
     {
+      id: '126',
       label: 'Social',
       selected: false,
       type: 'topic',
       children: [
         {
+          id: '127',
           label: 'Social 1',
           selected: false,
           type: 'subtopic',
+          children: [],
         },
         {
+          id: '128',
           label: 'Social 2',
           selected: false,
           type: 'subtopic',
+          children: [],
         }
       ],
     },
     {
+      id: '129',
       label: 'Economic',
       selected: false,
       type: 'topic',
       children: [
         {
+          id: '130',
           label: 'Econ 1',
           selected: false,
           type: 'subtopic',
+          children: [],
         },
         {
+          id: '131',
           label: 'Econ 2',
           selected: false,
           type: 'subtopic',
+          children: [],
         }
       ],
     },
     {
+      id: '132',
       label: 'Housing',
       selected: false,
       type: 'topic',
       children: [
         {
+          id: '133',
           label: 'Housing Stat 1',
           selected: false,
           type: 'subtopic',
+          children: [],
         },
         {
+          id: '134',
           label: 'Housing Stat 2',
           selected: false,
           type: 'subtopic',
+          children: [],
         }
       ],
     },
-  ]
+  ];
+
+  @action setTopics(newTopics) {
+    this.topics = newTopics;
+  }
 }

--- a/app/templates/components/explorer/topic-select-dropdown.hbs
+++ b/app/templates/components/explorer/topic-select-dropdown.hbs
@@ -1,7 +1,7 @@
 <button
   class="topic-select-toggle button gray expanded no-margin"
   role="button"
-  {{action (mut this.open) (not this.open)}}
+  {{on "click" this.toggleOpen}}
 >
   <div class="grid-x full">
     <div class="cell small-11">
@@ -18,9 +18,10 @@
 
 {{#if this.open}}
   <div class="topic-menu">
-    {{#each @topics as |topic|}}
+    {{#each @topics key="id" as |topic|}}
       <Ui::NestableListItem
         @item={{topic}}
+        @onItemToggle={{this.onListItemToggle}}
       />
     {{/each}}
   </div>

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -2,6 +2,7 @@
   <div class="cell small-12">
     <Explorer::TopicSelectDropdown
       @topics={{@topics}}
+      @setTopics={{@setTopics}}
     />
   </div>
   <div class="cell auto">

--- a/app/templates/components/ui/nestable-list-item.hbs
+++ b/app/templates/components/ui/nestable-list-item.hbs
@@ -2,7 +2,7 @@
   class="nestable-list-item grid-x {{if this.hasChildren 'clickable'}} {{@item.type}}-list-item"
 >
   <div class="cell small-1"
-    {{action (mut @item.selected) (not @item.selected)}}
+    {{on "click" (fn @onItemToggle @item.id)}}
   >
     <span class="dcp-orange">
       {{#if @item.selected}}
@@ -15,26 +15,31 @@
 
   <div
     class="cell auto"
-    {{action (mut this.open) (not this.open)}}
+    {{on "click" this.toggleOpen}}
   >
     {{@item.label}}
   </div>
 
-  <div class="cell small-1"
-    {{action (mut this.open) (not this.open)}}
-  >
+  <div class="cell small-1">
     {{#if this.hasChildren}}
-      {{fa-icon icon=(if this.open 'caret-up' 'caret-down')}}
+    <span
+      {{on "click" this.toggleOpen}}
+    >
+      {{fa-icon
+        icon=(if this.open 'caret-up' 'caret-down')
+      }}
+    </span>
     {{/if}}
   </div>
 
-  {{#if this.open}}
-    <div class="cell small-12">
-      {{#each @item.children as |child|}}
+  <div class="cell small-12">
+    {{#if this.open}}
+      {{#each @item.children key="id" as |child|}}
         <Ui::NestableListItem
           @item={{child}}
+          @onItemToggle={{@onItemToggle}}
         />
       {{/each}}
-    </div>
-  {{/if}}
+    {{/if}}
+  </div>
 </div>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -1,6 +1,7 @@
 <OrangeBar>
   <OrangeBarDataExplorer
     @topics={{this.topics}}
+    @setTopics={{this.setTopics}}
   />
 </OrangeBar>
 


### PR DESCRIPTION
### Summary
This PR introduces actions to update a state array representing selected topics. It ties checkboxes in the topic selection dropdown to the new actions. The actions will make sure that toggling a parent topic results in toggling child topics.

#### Tasks/Bug Numbers
 - Fixes [AB#3179](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3179)


