### PR TITLE
3183 Merge Profile n Topic route into Explorer route

### DIFF
--- a/app/adapters/row.js
+++ b/app/adapters/row.js
@@ -7,8 +7,8 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { selectionId, comparator = 0, type } = query;
-    const URL = `${SupportServiceHost}/profile/${selectionId}/${type}?compare=${comparator}`;
+    const { selectionId, comparator = 0 } = query;
+    const URL = `${SupportServiceHost}/profile/${selectionId}?compare=${comparator}`;
 
     return fetch(URL)
       .then(d => d.json());

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -2,6 +2,15 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
+import demographic from '../table-config/demographic';
+
+const {
+  sexAndAge,
+  mutuallyExclusiveRaceHispanicOrigin,
+  hispanicSubgroup,
+  asianSubgroup,
+} = demographic;
+
 export default class ExplorerController extends Controller {
   showChart = true;
 
@@ -12,6 +21,15 @@ export default class ExplorerController extends Controller {
   disaggregate = false;
 
   compareTo = null;
+
+  mode = 'current';
+
+  rowConfigs = {
+    sexAndAge,
+    mutuallyExclusiveRaceHispanicOrigin,
+    hispanicSubgroup,
+    asianSubgroup,
+  };
 
   @tracked topics = [
     {

--- a/app/routes/explorer.js
+++ b/app/routes/explorer.js
@@ -1,17 +1,32 @@
 import Route from '@ember/routing/route';
 import Environment from '../config/environment';
+import nestProfile from '../utils/nest-profile';
 
 const { SupportServiceHost } = Environment;
 
-const SELECTION_API_URL = id => `${SupportServiceHost}/explorer/${id}`;
+const SELECTION_API_URL = id => `${SupportServiceHost}/selection/${id}`;
 
 export default class ExplorerRoute extends Route {
-  model({ id }) { // eslint-disable-line
-    if (id) {
-      return fetch(SELECTION_API_URL(id))
-        .then(response => response.json());
-    }
+  beforeModel() {
+    this.store.unloadAll('row');
+  }
 
-    return fetch(SELECTION_API_URL('nyc'));
+  async model({ id }) { // eslint-disable-line
+    let selectionResponse = null;
+    let profileResponse = null;
+    let selectionId = id || 'nyc';
+
+    selectionResponse = await fetch(SELECTION_API_URL(id));
+    selectionResponse = await selectionResponse.json();
+
+    profileResponse = await this.store.query('row', { selectionId, comparator: '0' });
+    profileResponse = profileResponse.toArray();
+
+    const nestedProfileModel = nestProfile(profileResponse, 'variable');
+
+    return {
+      selection: selectionResponse,
+      profile: nestedProfileModel,
+    };
   }
 }

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -7,6 +7,36 @@
 
 <div class="overflow-y-grid grid-padding-x" id="explorer-wrapper">
   <div class="cell auto" id="explorer-content">
-    {{outlet}}
+    {{data-table
+      mode='current'
+      reliability=false
+      comparison=false
+      config=this.rowConfigs.sexAndAge
+      model=@model.profile
+    }}
+
+    {{data-table
+      mode='current'
+      reliability=false
+      comparison=false
+      config=this.rowConfigs.mutuallyExclusiveRaceHispanicOrigin
+      model=@model.profile
+    }}
+
+    {{data-table
+      mode='current'
+      reliability=false
+      comparison=false
+      config=this.rowConfigs.hispanicSubgroup
+      model=@model.profile
+    }}
+
+    {{data-table
+      mode='current'
+      reliability=false
+      comparison=false
+      config=this.rowConfigs.asianSubgroup
+      model=@model.profile
+    }}
   </div>
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -141,7 +141,7 @@ module.exports = function (environment) {
     // ENV.DEFAULT_SELECTION = SAMPLE_SELECTION;
     ENV.SupportServiceHost = 'https://factfinder-api.herokuapp.com';
     ENV['ember-cli-mirage'] = {
-      enabled: false,
+      enabled: true,
     };
   }
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -29,6 +29,11 @@ export default function() {
     selection: selectionAllNTA,
   }));
 
+  this.get('/selection', () => selectionAllNTA);
+  this.get('/selection/:id', () => selectionAllNTA);
+
+  this.get('/profile', () => profilesAllNTA);
+  this.get('/profile/:id', () => profilesAllNTA);
 
   /*
     Passthroughs


### PR DESCRIPTION
- Combines /profile and /<topic> (/demographic, /sex-and-age, etc) routes into one route: /explorer
- /explorer model is combination of  both /profile and /topic models 
- Moves Downloadable Mixin procedures/transformations into explorer route

API ARCHITECTURE CHANGE ASSUMPTION (debatable):
 - remove /profie/id/**/<topic>** subroute.  Load all topics at once in exploer.
   - pros: faster ui
   - cons: tiny bit slower to load explorer page

Fixes [AB#3183](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3183)

Other:
  - re-enables Mirage in development mode 