### PR TITLE
3595 fix orange bar arch

### DIFF
--- a/app/components/orange-bar-custom-map-study.js
+++ b/app/components/orange-bar-custom-map-study.js
@@ -14,8 +14,6 @@ export default Component.extend({
 
   choroplethConfigs,
 
-  classNames: ['orange-bar-custom-map-study'],
-
   selectionCount: alias('selection.selectedCount'),
   mode: 'direct-select',
   advanced: false,

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -52,6 +52,7 @@ $table-border: 1px solid $silver;
 @import "ember-power-select";
 
 // Component styles
+@import 'modules/components/custom-map-study/toolbar';
 @import 'modules/components/explorer/toolbar';
 @import 'modules/components/explorer/topic-select-dropdown';
 @import 'modules/components/explorer/source-select-dropdown';

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -245,25 +245,6 @@ body {
   margin-bottom: 0;
 }
 
-.search {
-  position: relative;
-  bottom: 50vh;
-  left: -$global-margin;
-  z-index: 100;
-  margin-left: 50px;
-  margin-bottom: rem-calc(-40);
-
-  @include breakpoint(large) {
-    // position: absolute;
-    position: relative;
-    top: 0;
-    bottom: auto;
-    left: 0;
-    width: rem-calc(300);
-    margin-left: 0;
-    // margin-top: rem-calc(-92);
-  }
-}
 
 .call-to-action {
   margin-bottom: $global-margin;

--- a/app/styles/modules/_m-orange-bar.scss
+++ b/app/styles/modules/_m-orange-bar.scss
@@ -6,9 +6,14 @@
   align-items: center;
   text-align: center;
   z-index: 10;
+  display: block !important;
+
 
   .bar-item {
     position: relative !important;
+    line-height: 1.5;
+    font-size:  rem-calc(14);
+    font-weight: $global-weight-bold;
   }
 }
 

--- a/app/styles/modules/_m-orange-bar.scss
+++ b/app/styles/modules/_m-orange-bar.scss
@@ -8,7 +8,6 @@
   z-index: 10;
   display: block !important;
 
-
   .bar-item {
     position: relative !important;
     line-height: 1.5;
@@ -25,24 +24,21 @@
   font-weight: $global-weight-bold;
   box-shadow: 0 4px 0 0 rgba(0,0,0,0.1);
 
-  @include breakpoint(large) {
-    border-radius: 4px;
-    box-shadow: 0 0 0 2px $white;
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px $white;
+  display: flex !important;
 
-    li:not(:last-child) {
-      border-right: 1px solid $white;
-    }
+  li:not(:last-child) {
+    border-right: 1px solid $white;
   }
 
   .dropdown-content a {
-    @include breakpoint(large) {
+    box-shadow: 0 0 0 2px $white;
+
+    &:last-child {
+      border-radius: 0 0 4px 4px;
       box-shadow: 0 0 0 2px $white;
-  
-      &:last-child {
-        border-radius: 0 0 4px 4px;
-        box-shadow: 0 0 0 2px $white;
-        border-bottom: 1px solid $white;
-      }
+      border-bottom: 1px solid $white;
     }
   }
 
@@ -76,7 +72,7 @@
   }
 }
 .dropsizer {
-  width: auto;
+  width: 100px;
   position: relative;
   border-radius: 4px;
   border-right: 1px solid $white;
@@ -84,6 +80,7 @@
 
 ul .menu li.dropdown {
   display: inline-block;
+  width: 100px;
 }
 .dropdown:hover div, .dropdown:hover .dropdown-content {
   display: block;
@@ -92,35 +89,43 @@ ul .menu li.dropdown {
   position: relative;
 }
 .dropbtn {
-  // display: inline-block !important;
-  display: flex !important;
-  // justify-content: center;
+  width: 100px;
   align-items: center;
   height: 100%;
 }
 
 #more-options-button {
-  margin-right: 46px;
   font-style: normal;
   font-weight: bold;
   font-size: 16px;
   line-height: 26px;
+  width: 150px !important;
+
+  ul, li {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
 }
+
 #draw-tools {
-  margin-left: 31px;
-  margin-right: 20px;
-  width:ceil($number: 100px);
+  width: 100px;
 }
-.five-buttons li {
-  width: 79px;
-  // padding: 0px;
-  align-items: center;
-}
-.five-buttons li.active {
-  background-color: white;
-}
-.five-buttons li.active a {
-  color: #d96b27;
+
+.five-buttons {
+  margin-top: -5px;
+
+  li {
+    width: 100px;
+    // padding: 0px;
+    align-items: center;
+  }
+  li.active {
+    background-color: white;
+  }
+  li.active a {
+    color: #d96b27;
+  }
 }
 
 .dropbtn-centered {
@@ -128,13 +133,4 @@ ul .menu li.dropdown {
 }
 .dropbtn-left {
   justify-content: left;
-}
-
-.orange-bar-custom-map-study {
-  width: 100%;
-  align-items: center;
-  text-align: center;
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
 }

--- a/app/styles/modules/components/custom-map-study/toolbar.scss
+++ b/app/styles/modules/components/custom-map-study/toolbar.scss
@@ -1,0 +1,5 @@
+#custom-map-study-toolbar {
+  margin-left: 15px !important;
+  margin-right: 15px !important;
+  padding-top: 15px;
+}

--- a/app/styles/modules/components/explorer/source-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/source-select-dropdown.scss
@@ -7,6 +7,7 @@
   padding-top: 0;
   padding-bottom: 0;
   border-radius: 5px;
+  padding: 11px 5px;
 }
 
 .selected-source {

--- a/app/styles/modules/components/explorer/toolbar.scss
+++ b/app/styles/modules/components/explorer/toolbar.scss
@@ -1,4 +1,5 @@
 #data-explorer-toolbar {
   margin-left: 15px !important;
   margin-right: 15px !important;
+  padding-top: 15px;
 }

--- a/app/styles/modules/components/explorer/topic-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/topic-select-dropdown.scss
@@ -4,8 +4,7 @@
 
 .topic-select-toggle {
   width: 250px !important;
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 11px 5px;
   border-radius: 5px;
 }
 

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -1,6 +1,9 @@
-<li class="cell medium-shrink">
-  <ul class="menu">
-    <li style="flex-grow: 0;">
+<div
+  id="custom-map-study-toolbar"
+  class="grid-container fluid orange-bar-custom-map-study"
+>
+  <div class="grid-x grid-margin-x">
+    <div class="cell small-1 bar-item">
       <ul class="menu orange-bar--selector" id="draw-tools">
         <li class="dropdown">
           <a href="#" class="dropbtn dropbtn-left">
@@ -21,164 +24,175 @@
                 {{fa-icon icon='dot-circle' prefix='far'}}
                 <span class="hide-for-medium">Draw</span> Radius
               </a>
-            </div>      
+            </div>
           </div>
         </li>
       </ul>
-    </li>
-    <li class="search">
-      <MapSearch />
-    </li>
-  </ul>
-</li>
-<li>
-  <ul class="menu align-center orange-bar--selector five-buttons">
-    <li class="{{if (eq this.selection.summaryLevel 'blocks') 'active'}} explode-block">
-      <a href="#" data-test-toggle-blocks {{action this.handleSummaryLevelToggle 'blocks'}}>
-        <span class="show-for-medium">Census </span>
-        Block
-      </a>
-      {{ember-tooltip delay=500 text='Create selection area using census blocks'}}
-    </li>
-    <li class="{{if (eq this.selection.summaryLevel 'tracts') 'active'}} explode-tract">
-      <a href="#" data-test-toggle-tracts {{action this.handleSummaryLevelToggle 'tracts'}}>
-        <span class="show-for-medium">Census </span>
-        Tract
-      </a>
-      {{ember-tooltip delay=500 text='Create selection area using census tracts'}}
-    </li>
-    <li class="{{if (eq this.selection.summaryLevel 'ntas') 'active'}} explode-nta">
-      <a href="#" data-test-toggle-ntas {{action this.handleSummaryLevelToggle 'ntas'}}>Neighborhood&nbsp;<br /><small>(NTA)</small></a>
-      {{ember-tooltip delay=500 text='Create selection area using Neighborhood Tabulation Areas'}}
-    </li>
-    <li class="{{if (eq this.selection.summaryLevel 'pumas') 'active'}} explode-puma">
-      <a href="#" data-test-toggle-pumas {{action this.handleSummaryLevelToggle 'pumas'}}>PUMA</a>
-      {{ember-tooltip delay=500 text='Create selection area using Public Use Microdata Areas'}}
-    </li>
-    <li class="dropdown explode-moregeos">
-      <a href="#" class="dropbtn dropbtn-centered">More Geographies</a>
-      <div class="dropsizer">
-        <div class="dropdown-content">
-          <a href="#">Census Block</a>
-          <a href="#">Borough</a>
-          <a href="#">New York City</a>
-        </div>      
+    </div>
+    <div class="cell small-3 bar-item">
+      <div class="search">
+        <MapSearch />
       </div>
-    </li>
-  </ul>
-</li>
-{{!-- <li class="menu align-right"><a href="#">Right Side Placeholder</a></li> --}}
-<li class="menu align-right">
-
-
-  <ul class="menu orange-bar--selector" id="more-options-button">
-    <li><a {{action "toggleAdvancedOptions"}}>More Options</a></li>
-  </ul>
-  
-</li>
-
-{{#if (eq @mode 'direct-select')}}
-  <div class="advanced-options {{unless this.advanced 'closed'}}" style="color:black">
-    {{#unless this.closed}}
-
-      <div class="selection-helpers">
-      </div>
-
-      <div class="layers-menu">
-        {{#layer-menu-item for='choropleths' as |item|}}
-          <div class="grid-x">
-            <div class="cell small-8">
-              <ul class="radio-buttons-list">
-                {{#each-in (group-by "group" this.choroplethConfigs) as |group configs|}}
-                  <h5 style="margin:0.5rem 0 0;font-size:1em;">{{group}}</h5>
-                  <ul class="no-bullet">
-                    {{#each configs as |config|}}
-                      <li {{
-                        action (
-                          queue
-                            (action this.setChoroplethMode config.id)
-                            (action item.updatePaintFor 'choropleth-nta-fill' this.choroplethPaintFill)
-                            (action item.updatePaintFor 'choropleth-nta-line' this.choroplethPaintLine)
-                        )
-                      }}>
-                        {{#if (eq this.choroplethMode config.id)}}
-                          {{fa-icon icon='dot-circle' prefix='far'}}
-                        {{else}}
-                          {{fa-icon icon='circle' prefix='far'}}
-                        {{/if}}
-                        {{config.label}}
-                        {{labs-ui/icon-tooltip tip=config.tooltip}}
-                      </li>
-                    {{/each}}
-                  </ul>
-                {{/each-in}}
-              </ul>
-            </div>
-            <div class="cell small-4">
-              <div class="legend">
-                <div class="legend-title">{{this.legendTitle}}</div>
-                {{#each this.stops as |stop|}}
-                  <div class="legend-item">
-                    <span class="legend-color" style={{sanitize-style (hash color=stop.color)}}>{{fa-icon icon='square'}}</span>
-                    {{stop.label}}
-                  </div>
-                {{/each}}
+    </div>
+    <div class="cell shrink bar-item">
+      <ul class="menu">
+        <li style="flex-grow: 0;">
+          <ul class="menu align-center orange-bar--selector five-buttons">
+            <li class="{{if (eq this.selection.summaryLevel 'blocks') 'active'}} explode-block">
+              <a href="#" data-test-toggle-blocks {{action this.handleSummaryLevelToggle 'blocks'}}>
+                <span class="show-for-medium">Census </span>
+                Block
+              </a>
+              {{ember-tooltip delay=500 text='Create selection area using census blocks'}}
+            </li>
+            <li class="{{if (eq this.selection.summaryLevel 'tracts') 'active'}} explode-tract">
+              <a href="#" data-test-toggle-tracts {{action this.handleSummaryLevelToggle 'tracts'}}>
+                <span class="show-for-medium">Census </span>
+                Tract
+              </a>
+              {{ember-tooltip delay=500 text='Create selection area using census tracts'}}
+            </li>
+            <li class="{{if (eq this.selection.summaryLevel 'ntas') 'active'}} explode-nta">
+              <a href="#" data-test-toggle-ntas {{action this.handleSummaryLevelToggle 'ntas'}}>Neighborhood&nbsp;<br /><small>(NTA)</small></a>
+              {{ember-tooltip delay=500 text='Create selection area using Neighborhood Tabulation Areas'}}
+            </li>
+            <li class="{{if (eq this.selection.summaryLevel 'pumas') 'active'}} explode-puma">
+              <a href="#" data-test-toggle-pumas {{action this.handleSummaryLevelToggle 'pumas'}}>PUMA</a>
+              {{ember-tooltip delay=500 text='Create selection area using Public Use Microdata Areas'}}
+            </li>
+            <li class="dropdown explode-moregeos">
+              <a href="#" class="dropbtn dropbtn-centered">More Geographies</a>
+              <div class="dropsizer">
+                <div class="dropdown-content">
+                  <a href="#">Census Block</a>
+                  <a href="#">Borough</a>
+                  <a href="#">New York City</a>
+                </div>
               </div>
-            </div>
-          </div>
-        {{/layer-menu-item}}
-
-        {{#lookup-layer-group for='subway' as |layerGroup|}}
-          {{#labs-ui/layer-group-toggle
-            label=layerGroup.model.legend.label
-            active=layerGroup.model.visible
-            icon=layerGroup.model.legend.icon
-          }}
-          {{/labs-ui/layer-group-toggle}}
-        {{/lookup-layer-group}}
-
-        {{#lookup-layer-group for='neighborhood-tabulation-areas' as |layerGroup|}}
-          {{#labs-ui/layer-group-toggle
-            label=layerGroup.model.legend.label
-            active=layerGroup.model.visible
-            icon=layerGroup.model.legend.icon
-          }}
-          {{/labs-ui/layer-group-toggle}}
-        {{/lookup-layer-group}}
-
-        {{#lookup-layer-group for='community-districts' as |layerGroup|}}
-          {{#labs-ui/layer-group-toggle
-            label=layerGroup.model.legend.label
-            active=layerGroup.model.visible
-            icon=layerGroup.model.legend.icon
-          }}
-          {{/labs-ui/layer-group-toggle}}
-        {{/lookup-layer-group}}
-
-        {{#lookup-layer-group for='nyc-pumas' as |layerGroup|}}
-          {{#labs-ui/layer-group-toggle
-            label=layerGroup.model.legend.label
-            active=layerGroup.model.visible
-            icon=layerGroup.model.legend.icon
-          }}
-          {{/labs-ui/layer-group-toggle}}
-        {{/lookup-layer-group}}
-
-        {{#lookup-layer-group for='nyc-council-districts' as |layerGroup|}}
-          {{#labs-ui/layer-group-toggle
-            label=layerGroup.model.legend.label
-            active=layerGroup.model.visible
-            icon=layerGroup.model.legend.icon
-          }}
-          {{/labs-ui/layer-group-toggle}}
-        {{/lookup-layer-group}}
-
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+    {{!-- <li class="menu align-right"><a href="#">Right Side Placeholder</a></li> --}}
+    <div class="cell small-1 bar-item">
+    </div>
+    <div class="cell small-2 bar-item">
+      <div class="menu align-right">
+        <ul class="menu orange-bar--selector" id="more-options-button">
+          <li>
+            <a {{action "toggleAdvancedOptions"}}>
+              More Options
+            </a>
+          </li>
+        </ul>
       </div>
+    </div>
 
-      {{yield}}
+    {{#if (eq @mode 'direct-select')}}
+      <div class="advanced-options {{unless this.advanced 'closed'}}" style="color:black">
+        {{#unless this.closed}}
 
-    {{/unless}}
+          <div class="selection-helpers">
+          </div>
+
+          <div class="layers-menu">
+            {{#layer-menu-item for='choropleths' as |item|}}
+              <div class="grid-x">
+                <div class="cell small-8">
+                  <ul class="radio-buttons-list">
+                    {{#each-in (group-by "group" this.choroplethConfigs) as |group configs|}}
+                      <h5 style="margin:0.5rem 0 0;font-size:1em;">{{group}}</h5>
+                      <ul class="no-bullet">
+                        {{#each configs as |config|}}
+                          <li {{
+                            action (
+                              queue
+                                (action this.setChoroplethMode config.id)
+                                (action item.updatePaintFor 'choropleth-nta-fill' this.choroplethPaintFill)
+                                (action item.updatePaintFor 'choropleth-nta-line' this.choroplethPaintLine)
+                            )
+                          }}>
+                            {{#if (eq this.choroplethMode config.id)}}
+                              {{fa-icon icon='dot-circle' prefix='far'}}
+                            {{else}}
+                              {{fa-icon icon='circle' prefix='far'}}
+                            {{/if}}
+                            {{config.label}}
+                            {{labs-ui/icon-tooltip tip=config.tooltip}}
+                          </li>
+                        {{/each}}
+                      </ul>
+                    {{/each-in}}
+                  </ul>
+                </div>
+                <div class="cell small-4">
+                  <div class="legend">
+                    <div class="legend-title">{{this.legendTitle}}</div>
+                    {{#each this.stops as |stop|}}
+                      <div class="legend-item">
+                        <span class="legend-color" style={{sanitize-style (hash color=stop.color)}}>{{fa-icon icon='square'}}</span>
+                        {{stop.label}}
+                      </div>
+                    {{/each}}
+                  </div>
+                </div>
+              </div>
+            {{/layer-menu-item}}
+
+            {{#lookup-layer-group for='subway' as |layerGroup|}}
+              {{#labs-ui/layer-group-toggle
+                label=layerGroup.model.legend.label
+                active=layerGroup.model.visible
+                icon=layerGroup.model.legend.icon
+              }}
+              {{/labs-ui/layer-group-toggle}}
+            {{/lookup-layer-group}}
+
+            {{#lookup-layer-group for='neighborhood-tabulation-areas' as |layerGroup|}}
+              {{#labs-ui/layer-group-toggle
+                label=layerGroup.model.legend.label
+                active=layerGroup.model.visible
+                icon=layerGroup.model.legend.icon
+              }}
+              {{/labs-ui/layer-group-toggle}}
+            {{/lookup-layer-group}}
+
+            {{#lookup-layer-group for='community-districts' as |layerGroup|}}
+              {{#labs-ui/layer-group-toggle
+                label=layerGroup.model.legend.label
+                active=layerGroup.model.visible
+                icon=layerGroup.model.legend.icon
+              }}
+              {{/labs-ui/layer-group-toggle}}
+            {{/lookup-layer-group}}
+
+            {{#lookup-layer-group for='nyc-pumas' as |layerGroup|}}
+              {{#labs-ui/layer-group-toggle
+                label=layerGroup.model.legend.label
+                active=layerGroup.model.visible
+                icon=layerGroup.model.legend.icon
+              }}
+              {{/labs-ui/layer-group-toggle}}
+            {{/lookup-layer-group}}
+
+            {{#lookup-layer-group for='nyc-council-districts' as |layerGroup|}}
+              {{#labs-ui/layer-group-toggle
+                label=layerGroup.model.legend.label
+                active=layerGroup.model.visible
+                icon=layerGroup.model.legend.icon
+              }}
+              {{/labs-ui/layer-group-toggle}}
+            {{/lookup-layer-group}}
+
+          </div>
+
+          {{yield}}
+
+        {{/unless}}
+      </div>
+    {{else}}
+      {{component @mode}}
+    {{/if}}
   </div>
-{{else}}
-  {{component @mode}}
-{{/if}}
+</div>

--- a/app/templates/components/orange-bar.hbs
+++ b/app/templates/components/orange-bar.hbs
@@ -1,3 +1,3 @@
-<ul class="menu expanded orange-bar">
+<div class="orange-bar">
   {{yield}}
-</ul>
+</div>


### PR DESCRIPTION
### Summary
Reworks the orange bar to use the Foundation XY Grid system to organize its layout at the top level, instead of the Foundation Menu component styles. Within each XY Grid cell, the Custom Map Study orange toolbar still uses the Foundation Menu component styles and system of `<ul>` and `<li>`.

However, using the XY Grid at the top level allows us to space items apart across the entire width of the toolbar in a more predictable way. E.g. one set of buttons on the left, another set on the right.  It also sets us up for success when we do mobile work in the future. 

This PR also removes unnecessary, over-complex code.

#### Tasks/Bug Numbers
 - Fixes [AB#3595](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3595)

#### Technial explanation
- The `orange-bar` base component now is a `<div>` instead of a `<ul>`, making horizontal sizing (full screen width) of the toolbar easier because we are using the conventional div box model. 
- **Key concept:** Notice how each item (Draw button, Searchbar, Geography selection buttons,  More Options) in the Custom Map Study toolbar is now wrapped in a `<div class="cell ...">`. 
- A lot of buttons and items are now **fixed-with** using specific `px` values in order to make the UI more predictable and styling easier.
- This PR removed some mobile breakpoint CSS to clear up the styling. We can make a focused effort to style for mobile in the mobile development phase