### PR TITLE
Adjust position of Explorer toolbar buttons.

### DIFF
--- a/app/styles/modules/components/explorer/modify-tables-menu.scss
+++ b/app/styles/modules/components/explorer/modify-tables-menu.scss
@@ -8,7 +8,7 @@
 .modify-tables-menu {
   position: absolute;
   top: 100%;
-  left: -30px;
+  left: -42px;
   margin-top: 15px;
   bottom: auto;
   background-color: $white;
@@ -23,7 +23,7 @@
   .triangle {
     position: absolute;
     top: -15px;
-    left: 95px;
+    left: 105px;
     width: 0;
     height: 0;
     border-left: 15px solid transparent;

--- a/app/styles/modules/components/explorer/source-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/source-select-dropdown.scss
@@ -26,7 +26,7 @@
   width: 250px !important;
   color: $dark-gray;
   border: 1px solid rgb(223, 225, 229);
-  border-radius: 0 0px 5px 5px;
+  border-radius: 5px;
   text-align: left !important;
 
   .clickable {

--- a/app/styles/modules/components/explorer/topic-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/topic-select-dropdown.scss
@@ -24,7 +24,7 @@
   width: 250px !important;
   color: $dark-gray;
   border: 1px solid rgb(223, 225, 229);
-  border-radius: 0 0px 5px 5px;
+  border-radius: 5px;
   text-align: left !important;
 
   .clickable {

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -3,26 +3,33 @@
   class="grid-container fluid"
 >
   <div class="grid-x grid-margin-x">
-    <div class="cell small-4 bar-item">
+    <div class="cell small-2 bar-item">
       <Explorer::SourceSelectDropdown
         @sources={{@sources}}
         @setSources={{@setSources}}
       />
     </div>
 
-    <div class="cell small-4 bar-item">
+    <div class="cell small-2 bar-item">
       <Explorer::TopicSelectDropdown
         @topics={{@topics}}
         @setTopics={{@setTopics}}
       />
     </div>
 
-    <div class="cell small-4 bar-item">
+    <div class="cell small-2 bar-item">
      <Explorer::ModifyTablesMenu
         @showReliability={{@showReliability}}
         @disaggregate={{@disaggregate}}
         @compareTo={{@compareTo}}
      />
+    </div>
+
+    <div class="cell auto">
+    </div>
+
+    <div class="cell small-2 bar-item">
+      Data Download Button
     </div>
   </div>
 </div>


### PR DESCRIPTION
Small adjustment of Explorer toolbar buttons to match wireframes. Now that #829  is merged, this was a silky smooth fix!

Also tweak dropdown border radius.
