### PR TITLE
2126 Change over Time selection

### DIFF
--- a/app/components/explorer/source-select-dropdown.js
+++ b/app/components/explorer/source-select-dropdown.js
@@ -13,6 +13,14 @@ export default class SourceSelectDropdownComponent extends Component {
     return this.args.sources.find(source => source.selected);
   }
 
+  get censusSources() {
+    return this.args.sources.filter(source => source.type === 'census');
+  }
+
+  get acsSources() {
+    return this.args.sources.filter(source => source.type === 'acs');
+  }
+
   toggleSourceInList = (sources, sourceId) => {
     return sources.map((source) => {
       if (source.id === sourceId) {

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -75,7 +75,7 @@ export default class ExplorerController extends Controller {
     {
       id: 'decennial - Population Density',
       label: 'Population Density',
-      selected: false,
+      selected: true,
       type: 'subtopic',
       config: decennialTopics.populationDensity,
       children: [],
@@ -83,7 +83,7 @@ export default class ExplorerController extends Controller {
     {
       id: 'decennial - Age and Sex',
       label: 'Age and Sex',
-      selected: false,
+      selected: true,
       type: 'subtopic',
       config: decennialTopics.sexAndAge,
       children: [],
@@ -91,7 +91,7 @@ export default class ExplorerController extends Controller {
     {
       id: 'decennial - Mutually Exclusive Race / Hispanic Origin',
       label: 'Mutually Exclusive Race / Hispanic Origin',
-      selected: false,
+      selected: true,
       type: 'subtopic',
       config: decennialTopics.mutuallyExclusiveRaceHispanicOrigin,
       children: [],
@@ -99,7 +99,7 @@ export default class ExplorerController extends Controller {
     {
       id: 'decennial - Hispanic Subgroup',
       label: 'Hispanic Subgroup',
-      selected: false,
+      selected: true,
       type: 'subtopic',
       config: decennialTopics.hispanicSubgroup,
       children: [],
@@ -107,7 +107,7 @@ export default class ExplorerController extends Controller {
     {
       id: 'decennial - Asian Subgroup',
       label: 'Asian Subgroup',
-      selected: false,
+      selected: true,
       type: 'subtopic',
       config: decennialTopics.asianSubgroup,
       children: [],

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -14,15 +14,53 @@ export default class ExplorerController extends Controller {
 
   @tracked sources = [
     {
-      id: 'decennial',
-      label: 'Decennial',
+      id: 'decennial-2020',
+      label: '2020 Decennial Census',
+      type: 'census',
+      year: '2020',
+      changeOverTime: false,
       selected: true,
     },
     {
-      id: 'acs',
-      label: 'ACS',
+      id: 'decennial-2010',
+      label: '2010 Decennial Census',
+      type: 'census',
+      year: '2010',
+      changeOverTime: false,
       selected: false,
-    }
+    },
+    {
+      id: 'decennial-change',
+      label: 'Change over Time: Decennial Census 2020, 2010',
+      type: 'census',
+      year: null,
+      changeOverTime: true,
+      selected: false,
+    },
+    {
+      id: 'acs-2015-2019',
+      label: '2015 - 2019 ACS',
+      type: 'acs',
+      year: '2015-2019',
+      changeOverTime: false,
+      selected: false,
+    },
+    {
+      id: 'acs-2006-2010',
+      label: '2006 - 2010 ACS',
+      type: 'acs',
+      year: '2006-2010',
+      changeOverTime: false,
+      selected: false,
+    },
+    {
+      id: 'acs-change',
+      label: 'Change over Time: ACS 2006-2010 to 2015-2019',
+      type: 'acs',
+      year: null,
+      changeOverTime: true,
+      selected: false,
+    },
   ];
 
   topic = null;
@@ -33,6 +71,7 @@ export default class ExplorerController extends Controller {
 
   @tracked compareTo = null;
 
+  // values are 'current' or 'change'
   @tracked mode = 'current';
 
   @tracked decennialTopics = [
@@ -219,7 +258,7 @@ export default class ExplorerController extends Controller {
   }
 
   get topics() {
-    if (this.source.id === 'decennial') {
+    if (this.source.type === 'census') {
       return this.decennialTopics;
     }
 
@@ -228,10 +267,10 @@ export default class ExplorerController extends Controller {
   }
 
   set topics(newTopics) {
-    if (this.source.id === 'decennial') {
+    if (this.source.type === 'census') {
       this.decennialTopics = newTopics;
     }
-    if (this.source.id === 'acs') {
+    if (this.source.type === 'acs') {
       this.acsTopics = newTopics;
     }
   }

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -71,9 +71,6 @@ export default class ExplorerController extends Controller {
 
   @tracked compareTo = null;
 
-  // values are 'current' or 'change'
-  @tracked mode = 'current';
-
   @tracked decennialTopics = [
     {
       id: 'decennial - Population Density',
@@ -251,6 +248,13 @@ export default class ExplorerController extends Controller {
 
   get source() {
     return this.sources.find(source => source.selected);
+  }
+
+  // returns either 'current' or 'change'
+  get mode() {
+    if (this.source.changeOverTime) return 'change';
+
+    return 'current';
   }
 
   @action setSources(newSources) {

--- a/app/styles/modules/components/explorer/modify-tables-menu.scss
+++ b/app/styles/modules/components/explorer/modify-tables-menu.scss
@@ -19,6 +19,7 @@
   border: 1px solid rgb(223, 225, 229);
   border-radius: 5px;
   text-align: left !important;
+  z-index: 100;
 
   .triangle {
     position: absolute;

--- a/app/styles/modules/components/explorer/source-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/source-select-dropdown.scss
@@ -3,9 +3,8 @@
 // --------------------------------------------------
 
 .source-select-toggle {
-  width: 250px !important;
-  padding-top: 0;
-  padding-bottom: 0;
+  width: 500px !important;
+  padding: 0.7rem 5px !important;
   border-radius: 5px;
   padding: 11px 5px;
 }
@@ -21,13 +20,14 @@
   bottom: auto;
   left: rem-calc(0);
   background-color: $white;
-  padding: rem-calc(6) 0;
+  padding: 15px;
   box-shadow: 0 4px 0 rgba(0,0,0,0.1);
-  width: 250px !important;
+  width: 500px !important;
   color: $dark-gray;
   border: 1px solid rgb(223, 225, 229);
   border-radius: 5px;
   text-align: left !important;
+  z-index: 100;
 
   .clickable {
     cursor: pointer;

--- a/app/styles/modules/components/explorer/topic-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/topic-select-dropdown.scss
@@ -26,9 +26,18 @@
   border: 1px solid rgb(223, 225, 229);
   border-radius: 5px;
   text-align: left !important;
+  z-index: 100;
 
   .clickable {
     cursor: pointer;
+  }
+
+  .nestable-list-item {
+    padding-left: 10px;
+  }
+
+  .nestable-list-item:not(:last-child) {
+    border-bottom: 1px solid rgb(223, 225, 229);
   }
 }
 

--- a/app/styles/modules/components/ui/nestable-list-item.scss
+++ b/app/styles/modules/components/ui/nestable-list-item.scss
@@ -11,7 +11,3 @@
 
   padding: 7px 5px;
 }
-
-.nestable-list-item:not(:last-child) {
-  border-bottom: 1px solid rgb(223, 225, 229);
-}

--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -18,7 +18,30 @@
 
 {{#if this.open}}
   <div class="source-menu">
-    {{#each @sources key="id" as |source|}}
+    Decennial Census
+    {{#each this.censusSources key="id" as |source|}}
+      <div
+        class="nestable-list-item grid-x clickable"
+        {{on "click" (fn this.onSourceToggle source.id)}}
+      >
+        <div class="cell small-1">
+          <span class="dcp-orange">
+            {{#if source.selected}}
+              {{fa-icon icon='dot-circle' prefix='far'}}
+            {{else}}
+              {{fa-icon icon='circle' prefix='far' class='silver'}}
+            {{/if}}
+          </span>
+        </div>
+
+        <div class="cell auto">
+          {{source.label}}
+        </div>
+      </div>
+    {{/each}}
+
+    American Community Survey (ACS)
+    {{#each this.acsSources key="id" as |source|}}
       <div
         class="nestable-list-item grid-x clickable"
         {{on "click" (fn this.onSourceToggle source.id)}}

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -3,14 +3,14 @@
   class="grid-container fluid"
 >
   <div class="grid-x grid-margin-x">
-    <div class="cell small-2 bar-item">
+    <div class="cell small-5 large-5 bar-item">
       <Explorer::SourceSelectDropdown
         @sources={{@sources}}
         @setSources={{@setSources}}
       />
     </div>
 
-    <div class="cell small-2 bar-item">
+    <div class="cell small-3 bar-item">
       <Explorer::TopicSelectDropdown
         @topics={{@topics}}
         @setTopics={{@setTopics}}
@@ -23,9 +23,6 @@
         @disaggregate={{@disaggregate}}
         @compareTo={{@compareTo}}
      />
-    </div>
-
-    <div class="cell auto">
     </div>
 
     <div class="cell small-2 bar-item">

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -12,7 +12,7 @@
 
 <div class="overflow-y-grid grid-padding-x">
   <div class="cell auto" id="explorer-wrapper">
-    {{#if (eq this.source.id 'decennial')}}
+    {{#if (eq this.source.type 'census')}}
       {{#each this.topics as |subtopic|}}
         {{#if subtopic.selected}}
           <div class="grid-x grid-margin-x">
@@ -35,7 +35,7 @@
       {{/each}}
     {{/if}}
 
-    {{#if (eq this.source.id 'acs')}}
+    {{#if (eq this.source.type 'acs')}}
       {{#each this.topics as |topic|}}
         {{#each topic.children as |subtopic|}}
           {{#if subtopic.selected}}

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -21,7 +21,7 @@
                 {{subtopic.label}}
               </h3>
               {{data-table
-                mode='current'
+                mode=this.mode
                 reliability=this.showReliability
                 comparison=this.compareTo
                 config=subtopic.config
@@ -45,7 +45,7 @@
                   {{subtopic.label}}
                 </h3>
                 {{data-table
-                  mode='current'
+                  mode=this.mode
                   reliability=this.showReliability
                   comparison=this.compareTo
                   config=subtopic.config


### PR DESCRIPTION
### Summary
Allows the user to select "Change over Time" Census and ACS source options in the Source selection dropdown. 

Includes miscellaneous styling adjustments. 

#### Tasks/Bug Numbers
 - Fixes [AB#2126](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2126)

### Technical Explanation
Reworks the Source objects to have more granular attributes, including a "changeOverTime" attribute which indicates if it represents a "Change over Time" source. 

Another new attribute on the source object is "type", which indicates if it is a Census or ACS source. Code should now reference this attribute to determine whether the current selected source is Census or ACS. 