### PR TITLE
Set align-spaced on CMS toolbar

### DIFF
--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -2,7 +2,7 @@
   id="custom-map-study-toolbar"
   class="grid-container fluid orange-bar-custom-map-study"
 >
-  <div class="grid-x grid-margin-x">
+  <div class="grid-x grid-margin-x align-spaced">
     <div class="cell small-1 bar-item">
       <ul class="menu orange-bar--selector" id="draw-tools">
         <li class="dropdown">
@@ -75,8 +75,6 @@
       </ul>
     </div>
     {{!-- <li class="menu align-right"><a href="#">Right Side Placeholder</a></li> --}}
-    <div class="cell small-1 bar-item">
-    </div>
     <div class="cell small-2 bar-item">
       <div class="menu align-right">
         <ul class="menu orange-bar--selector" id="more-options-button">


### PR DESCRIPTION
### Summary
Small PR to fix the More Options button jumping down on small-medium sized screens. The PR sets `align-spaced` on the parent grid-x container and removes a filler cell. Result is nicer spacing of buttons across the Custom Map Study toolbar. 