### PR TITLE
2126 Show Change over Time arrows

### DIFF
--- a/app/templates/components/data-table-header-change.hbs
+++ b/app/templates/components/data-table-header-change.hbs
@@ -16,13 +16,13 @@
         {{/unless}}
       </th>
       {{#if @decennial}}
-        <th colspan="{{if @reliability "5" "2"}}" class="text-center cell-border-bottom">2000</th>
         <th colspan="{{if @reliability "5" "2"}}" class="text-center cell-border-bottom">2010</th>
-        <th colspan="3" class="text-center cell-border-bottom">Change, 2000 to 2010</th>
+        <th colspan="{{if @reliability "5" "2"}}" class="text-center cell-border-bottom">2020</th>
+        <th colspan="3" class="text-center cell-border-bottom">Change, 2010 to 2020</th>
       {{else}}{{!-- acs --}}
         <th colspan="{{if @reliability "5" "2"}}" class="text-center cell-border-bottom">2006-2010</th>
-        <th colspan="{{if @reliability "5" "2"}}" class="text-center cell-border-bottom">2014-2018</th>
-        <th colspan="{{if @reliability "6" "3"}}" class="text-center cell-border-bottom">Change, 2006-2010 to 2014-2018</th>
+        <th colspan="{{if @reliability "5" "2"}}" class="text-center cell-border-bottom">2015-2019</th>
+        <th colspan="{{if @reliability "6" "3"}}" class="text-center cell-border-bottom">Change, 2006-2010 to 2015-2019</th>
       {{/if}}
     </tr>
     {{#if @reliability}}

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -25,10 +25,26 @@
 
   {{!-- Estimate --}}
   <td class="cell-border-left change-estimate {{unless @data.change_significant 'insignificant'}}">
-    {{unless (eq @data.change_sum null)
-      (format-number
-          @data.change_sum
-          precision=@rowConfig.decimal)}}
+    {{#unless (eq @data.change_sum null)}}
+      {{format-number
+        @data.change_sum
+        precision=@rowConfig.decimal
+      }}
+
+      {{#if (and
+        (gt @data.change_sum 0)
+        (lt @data.change_moe @data.change_sum)
+      )}}
+        {{fa-icon icon="arrow-up" class="green"}}
+      {{else if (and
+        (lt @data.change_sum 0)
+        (gt @data.change_m @data.change_sum)
+      )}}
+        {{fa-icon icon="arrow-down" class="red"}}
+      {{else}}
+        {{fa-icon icon=""}}
+      {{/if}}
+    {{/unless}}
   </td>
 
   {{#if @reliability}}
@@ -43,12 +59,26 @@
 
   {{!-- percent --}}
   <td class="{{unless @data.change_percent_significant 'insignificant'}} change-percent">
-    {{unless (eq @data.change_percent null)
-      (concat
+    {{#unless (eq @data.change_percent null)}}
+      {{concat
         (format-number (mult @data.change_percent 100) precision=1)
         '%'
-      )
-    }}
+      }}
+
+      {{#if (and
+        (gt @data.change_percent 0)
+        (lt @data.change_percent_m @data.change_percent)
+      )}}
+        {{fa-icon icon="arrow-up" class="green"}}
+      {{else if (and
+        (lt @data.change_percent 0)
+        (gt @data.change_percent_m @data.change_percent)
+      )}}
+        {{fa-icon icon="arrow-down" class="red"}}
+      {{else}}
+        {{fa-icon icon=""}}
+      {{/if}}
+    {{/unless}}
   </td>
 
   {{#if @reliability}}
@@ -66,13 +96,28 @@
   {{!-- percentage point --}}
   <td class="{{unless @data.change_percentage_point_significant 'insignificant'}} change-percentage-point">
     {{#unless
-        (or
-          @data.isSpecial
-          (eq @data.change_percentage_point null)
-        )}}
+      (or
+        @data.isSpecial
+        (eq @data.change_percentage_point null)
+      )
+    }}
       {{format-number
         (mult @data.change_percentage_point 100)
         precision=1}}
+
+      {{#if (and
+        (gt @data.change_percentage_point 0)
+        (lt @data.change_percentage_point_m @data.change_percentage_point)
+      )}}
+        {{fa-icon icon="arrow-up" class="green"}}
+      {{else if (and
+        (lt @data.change_percentage_point 0)
+        (gt @data.change_percentage_point_m @data.change_percentage_point)
+      )}}
+        {{fa-icon icon="arrow-down" class="red"}}
+      {{else}}
+        {{fa-icon icon=""}}
+      {{/if}}
     {{/unless}}
   </td>
 

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -22,6 +22,7 @@
               </h3>
               {{data-table
                 mode=this.mode
+                decennial=(eq this.source.type 'census')
                 reliability=this.showReliability
                 comparison=this.compareTo
                 config=subtopic.config
@@ -46,6 +47,7 @@
                 </h3>
                 {{data-table
                   mode=this.mode
+                  decennial=(eq this.source.type 'census')
                   reliability=this.showReliability
                   comparison=this.compareTo
                   config=subtopic.config

--- a/config/environment.js
+++ b/config/environment.js
@@ -75,6 +75,7 @@ module.exports = function (environment) {
           'arrow-left',
           'arrow-right',
           'arrow-up',
+          'arrow-down',
           'building',
           'caret-down',
           'caret-up',


### PR DESCRIPTION
### Summary
Adds up and down arrows to the Change over Time columns. Up arrows correspond to positive values, and down to negative values.  

Had trouble adding an extra columns for the arrows and getting them to align properly with the headers, so adding them to inside the value cells for now. 

#### Tasks/Bug Numbers
Fixes [AB#2126](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2126)

### Technical Explanation
I was able to align subheaders to headers properly with `colspan` on `<th>`, but couldn't  seem  enough to line up cells to the subheaders, despite quadruple counting the cells to match the subheader column count.
