### PR TITLE
3196 Add basic example charts for some ACS

### DIFF
--- a/app/chart-config/demographic/index.js
+++ b/app/chart-config/demographic/index.js
@@ -1,0 +1,9 @@
+import raceGroupChartConfig from './race-group';
+import hispanicSubgroupChartConfig from './hispanic-subgroup';
+import asianSubgroupChartConfig from './asian-subgroup';
+
+export default {
+  raceGroupChartConfig,
+  hispanicSubgroupChartConfig,
+  asianSubgroupChartConfig,
+};

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -5,9 +5,11 @@ import { action } from '@ember/object';
 // Decennial Topics
 import decennialTopics from '../table-config/decennial';
 
-// ACS Demographic Profile Topics
-import acsDemographic from '../table-config/demographic';
+// ACS Profile Topics
+import acsDemographicTableConfig from '../table-config/demographic';
 import acsSocial from '../table-config/social';
+
+import acsDemographicChartConfig from '../chart-config/demographic';
 
 export default class ExplorerController extends Controller {
   showChart = true;
@@ -77,7 +79,8 @@ export default class ExplorerController extends Controller {
       label: 'Population Density',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.populationDensity,
+      tableConfig: decennialTopics.populationDensity,
+      chartConfig: null,
       children: [],
     },
     {
@@ -85,7 +88,8 @@ export default class ExplorerController extends Controller {
       label: 'Age and Sex',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.sexAndAge,
+      tableConfig: decennialTopics.sexAndAge,
+      chartConfig: null,
       children: [],
     },
     {
@@ -93,7 +97,8 @@ export default class ExplorerController extends Controller {
       label: 'Mutually Exclusive Race / Hispanic Origin',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.mutuallyExclusiveRaceHispanicOrigin,
+      tableConfig: decennialTopics.mutuallyExclusiveRaceHispanicOrigin,
+      chartConfig: null,
       children: [],
     },
     {
@@ -101,7 +106,8 @@ export default class ExplorerController extends Controller {
       label: 'Hispanic Subgroup',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.hispanicSubgroup,
+      tableConfig: decennialTopics.hispanicSubgroup,
+      chartConfig: null,
       children: [],
     },
     {
@@ -109,7 +115,8 @@ export default class ExplorerController extends Controller {
       label: 'Asian Subgroup',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.asianSubgroup,
+      tableConfig: decennialTopics.asianSubgroup,
+      chartConfig: null,
       children: [],
     },
     {
@@ -117,7 +124,8 @@ export default class ExplorerController extends Controller {
       label: 'Relationship to Head of Household',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.relationshipToHeadOfHouseholdHouseholder,
+      tableConfig: decennialTopics.relationshipToHeadOfHouseholdHouseholder,
+      chartConfig: null,
       children: [],
     },
     {
@@ -125,7 +133,8 @@ export default class ExplorerController extends Controller {
       label: 'Household Type',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.householdType,
+      tableConfig: decennialTopics.householdType,
+      chartConfig: null,
       children: [],
     },
     {
@@ -133,7 +142,8 @@ export default class ExplorerController extends Controller {
       label: 'Housing Occupancy',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.housingOccupancy,
+      tableConfig: decennialTopics.housingOccupancy,
+      chartConfig: null,
       children: [],
     },
     {
@@ -141,7 +151,8 @@ export default class ExplorerController extends Controller {
       label: 'Housing Tenure',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.housingTenure,
+      tableConfig: decennialTopics.housingTenure,
+      chartConfig: null,
       children: [],
     },
     {
@@ -149,7 +160,8 @@ export default class ExplorerController extends Controller {
       label: 'Tenure by Age of Householder',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.tenureByAgeOfHouseholder,
+      tableConfig: decennialTopics.tenureByAgeOfHouseholder,
+      chartConfig: null,
       children: [],
     },
     {
@@ -157,7 +169,8 @@ export default class ExplorerController extends Controller {
       label: 'Household Size',
       selected: true,
       type: 'subtopic',
-      config: decennialTopics.householdSize,
+      tableConfig: decennialTopics.householdSize,
+      chartConfig: null,
       children: [],
     },
   ];
@@ -175,7 +188,8 @@ export default class ExplorerController extends Controller {
           label: 'Sex and Age',
           selected: true,
           type: 'subtopic',
-          config: acsDemographic.sexAndAge,
+          tableConfig: acsDemographicTableConfig.sexAndAge,
+          chartConfig: null,
           children: [],
         },
         {
@@ -183,7 +197,9 @@ export default class ExplorerController extends Controller {
           label: 'Mutually Exclusive Race / Hispanic Origin',
           selected: true,
           type: 'subtopic',
-          config: acsDemographic.mutuallyExclusiveRaceHispanicOrigin,
+          tableConfig: acsDemographicTableConfig.mutuallyExclusiveRaceHispanicOrigin,
+          chartConfig: acsDemographicChartConfig.raceGroupChartConfig,
+          chartLabel: 'Percent Distribution of Race/Hispanic Origin Groups',
           children: [],
         },
         {
@@ -191,7 +207,9 @@ export default class ExplorerController extends Controller {
           label: 'Hispanic Subgroup',
           selected: true,
           type: 'subtopic',
-          config: acsDemographic.hispanicSubgroup,
+          tableConfig: acsDemographicTableConfig.hispanicSubgroup,
+          chartConfig: acsDemographicChartConfig.hispanicSubgroupChartConfig,
+          chartLabel: 'Percent Distribution of Hispanic Subgroups',
           children: [],
         },
         {
@@ -199,7 +217,9 @@ export default class ExplorerController extends Controller {
           label: 'Asian Subgroup',
           selected: true,
           type: 'subtopic',
-          config: acsDemographic.asianSubgroup,
+          tableConfig: acsDemographicTableConfig.asianSubgroup,
+          chartConfig: acsDemographicChartConfig.asianSubgroupChartConfig,
+          chartLabel: 'Percent Distribution of Asian Subgroups',
           children: [],
         }
       ],
@@ -215,7 +235,8 @@ export default class ExplorerController extends Controller {
           label: 'Ancestry',
           selected: false,
           type: 'subtopic',
-          config: acsSocial.ancestry,
+          tableConfig: acsSocial.ancestry,
+          chartConfig: null,
           children: [],
         },
         {
@@ -223,7 +244,8 @@ export default class ExplorerController extends Controller {
           label: 'Computers and Internet Use',
           selected: false,
           type: 'subtopic',
-          config: acsSocial.computersAndInternetUse,
+          tableConfig: acsSocial.computersAndInternetUse,
+          chartConfig: null,
           children: [],
         },
         {
@@ -231,7 +253,8 @@ export default class ExplorerController extends Controller {
           label: 'U.S. Citizenship Status',
           selected: false,
           type: 'subtopic',
-          config: acsSocial.uSCitizenshipStatus,
+          tableConfig: acsSocial.uSCitizenshipStatus,
+          chartConfig: null,
           children: [],
         },
         {
@@ -239,9 +262,10 @@ export default class ExplorerController extends Controller {
           label: 'Disability Status Of The Civilian Noninstitutionalized Population',
           selected: false,
           type: 'subtopic',
-          config: acsSocial.disabilityStatusOfTheCivilianNoninstitutionalizedPopulation,
+          tableConfig: acsSocial.disabilityStatusOfTheCivilianNoninstitutionalizedPopulation,
+          chartConfig: null,
           children: [],
-        }
+        },
       ],
     },
   ];

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -25,7 +25,7 @@
                 decennial=(eq this.source.type 'census')
                 reliability=this.showReliability
                 comparison=this.compareTo
-                config=subtopic.config
+                config=subtopic.tableConfig
                 model=@model.profile
               }}
             </div>
@@ -50,10 +50,20 @@
                   decennial=(eq this.source.type 'census')
                   reliability=this.showReliability
                   comparison=this.compareTo
-                  config=subtopic.config
+                  config=subtopic.tableConfig
                   model=@model.profile
                 }}
               </div>
+
+              {{#if (and (eq this.mode 'current') subtopic.chartConfig)}}
+                <div class="cell large-4 xxlarge-3">
+                  {{acs-bar
+                    title=subtopic.chartLabel
+                    config=subtopic.chartConfig
+                    data=@model.profile
+                    height=204}}
+                </div>
+              {{/if}}
             </div>
 
             <hr>


### PR DESCRIPTION
### Summary
Displays charts for some ACS demographic topics. We still need to go through all the topics and connect them to any (previously) available chart configurations. Not sure if it's a good use of time though if the incoming data has different variables or chart availability. 

Still need to implement chart toggle.

#### Tasks/Bug Numbers
 - Fixes [AB#3196](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3196)