### PR TITLE
3196 Add Show Charts toggle, Your Data header

### DIFF
--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -12,7 +12,7 @@ import acsSocial from '../table-config/social';
 import acsDemographicChartConfig from '../chart-config/demographic';
 
 export default class ExplorerController extends Controller {
-  showChart = true;
+  showCharts = true;
 
   @tracked sources = [
     {

--- a/app/styles/modules/components/explorer/modify-tables-menu.scss
+++ b/app/styles/modules/components/explorer/modify-tables-menu.scss
@@ -33,6 +33,6 @@
   }
 }
 
-.modify-tables-switch {
+.modify-tables-switch, .show-charts-switch {
   margin-top: 3px;
 }

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -12,6 +12,33 @@
 
 <div class="overflow-y-grid grid-padding-x">
   <div class="cell auto" id="explorer-wrapper">
+    <h1>
+      Your Data:
+    </h1>
+
+    <div class="grid-container fluid">
+      <div class="grid-x align-left">
+        <div class="cell shrink">
+          <div class="switch tiny show-charts-switch">
+            <Input
+              @id="show-charts-switch"
+              @type="checkbox"
+              @checked={{this.showCharts}}
+              name="show-charts-switch"
+              class="switch-input"
+            />
+            <label class="switch-paddle" for="show-charts-switch">
+            </label>
+          </div>
+        </div>
+        <div class="cell shrink text-left">
+          Show Charts
+        </div>
+      </div>
+    </div>
+
+    <br>
+
     {{#if (eq this.source.type 'census')}}
       {{#each this.topics as |subtopic|}}
         {{#if subtopic.selected}}
@@ -55,7 +82,11 @@
                 }}
               </div>
 
-              {{#if (and (eq this.mode 'current') subtopic.chartConfig)}}
+              {{#if (and
+                (eq this.mode 'current')
+                subtopic.chartConfig
+                this.showCharts
+              )}}
                 <div class="cell large-4 xxlarge-3">
                   {{acs-bar
                     title=subtopic.chartLabel


### PR DESCRIPTION
### Summary
Adds a switch to toggle the Explorer charts. 
Adds the "Your Data" header above the chart toggle.

Erica specified toggle shouldn't got into Modify Tables dropdown.

![image](https://user-images.githubusercontent.com/3311663/124024216-e68cd380-d9bc-11eb-97b8-13950f628199.png)


It does look a little awkward sitting in the blank space above the tables -- maybe later can explorer putting it in the toolbar. 


Fixes [AB#3196](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3196)