### PR TITLE
3196 Fill out Social topics, charts

### DIFF
--- a/app/chart-config/economic/index.js
+++ b/app/chart-config/economic/index.js
@@ -1,0 +1,14 @@
+import classOfWorkerChartConfig from './class-of-worker';
+import incomeAndBenefitsChartConfig from './income-and-benefits';
+import commuteToWorkChartConfig from './commute-to-work';
+import occupationChartConfig from './occupation';
+import ratioOfIncomeToPovertyLevelChartConfig from './ratio-of-income-to-poverty-level';
+
+
+export default {
+  classOfWorkerChartConfig,
+  incomeAndBenefitsChartConfig,
+  commuteToWorkChartConfig,
+  occupationChartConfig,
+  ratioOfIncomeToPovertyLevelChartConfig,
+};

--- a/app/chart-config/housing/index.js
+++ b/app/chart-config/housing/index.js
@@ -1,0 +1,13 @@
+import grossRentGrapiChartConfig from './gross-rent-grapi';
+import grossRentChartConfig from './gross-rent';
+import housingTenureChartConfig from './housing-tenure';
+import valueChartConfig from './value';
+import vehiclesAvailableChartConfig from './vehicles-available';
+
+export default {
+  grossRentGrapiChartConfig,
+  grossRentChartConfig,
+  housingTenureChartConfig,
+  valueChartConfig,
+  vehiclesAvailableChartConfig,
+};

--- a/app/chart-config/social/index.js
+++ b/app/chart-config/social/index.js
@@ -1,0 +1,15 @@
+import householdTypeChartConfig from './household-type';
+import schoolEnrollmentChartConfig from './school-enrollment';
+import educationalAttainmentChartConfig from './educational-attainment';
+import residence1YearAgoChartConfig from './residence-1-year-ago';
+import placeOfBirthChartConfig from './place-of-birth';
+import foreignBornChartConfig from './foreign-born';
+
+export default {
+  householdTypeChartConfig,
+  schoolEnrollmentChartConfig,
+  educationalAttainmentChartConfig,
+  residence1YearAgoChartConfig,
+  placeOfBirthChartConfig,
+  foreignBornChartConfig,
+};

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -84,15 +84,18 @@
 
               {{#if (and
                 (eq this.mode 'current')
-                subtopic.chartConfig
+                subtopic.charts
                 this.showCharts
               )}}
                 <div class="cell large-4 xxlarge-3">
-                  {{acs-bar
-                    title=subtopic.chartLabel
-                    config=subtopic.chartConfig
-                    data=@model.profile
-                    height=204}}
+                  {{#each subtopic.charts as |chart|}}
+                    {{acs-bar
+                      title=chart.chartLabel
+                      config=chart.chartConfig
+                      data=@model.profile
+                      height=204
+                    }}
+                  {{/each}}
                 </div>
               {{/if}}
             </div>

--- a/app/topics-config/acs.js
+++ b/app/topics-config/acs.js
@@ -3,6 +3,7 @@ import acsDemographicTableConfig from '../table-config/demographic';
 import acsSocial from '../table-config/social';
 
 import acsDemographicChartConfig from '../chart-config/demographic';
+import acsSocialChartConfig from '../chart-config/social';
 
 export default [
   {
@@ -17,7 +18,7 @@ export default [
         selected: true,
         type: 'subtopic',
         tableConfig: acsDemographicTableConfig.sexAndAge,
-        chartConfig: null,
+        charts: null,
         children: [],
       },
       {
@@ -26,8 +27,12 @@ export default [
         selected: true,
         type: 'subtopic',
         tableConfig: acsDemographicTableConfig.mutuallyExclusiveRaceHispanicOrigin,
-        chartConfig: acsDemographicChartConfig.raceGroupChartConfig,
-        chartLabel: 'Percent Distribution of Race/Hispanic Origin Groups',
+        charts: [
+          {
+            chartConfig: acsDemographicChartConfig.raceGroupChartConfig,
+            chartLabel: 'Percent Distribution of Race/Hispanic Origin Groups',
+          },
+        ],
         children: [],
       },
       {
@@ -36,8 +41,12 @@ export default [
         selected: true,
         type: 'subtopic',
         tableConfig: acsDemographicTableConfig.hispanicSubgroup,
-        chartConfig: acsDemographicChartConfig.hispanicSubgroupChartConfig,
-        chartLabel: 'Percent Distribution of Hispanic Subgroups',
+        charts: [
+          {
+            chartConfig: acsDemographicChartConfig.hispanicSubgroupChartConfig,
+            chartLabel: 'Percent Distribution of Hispanic Subgroups',
+          },
+        ],
         children: [],
       },
       {
@@ -46,52 +55,184 @@ export default [
         selected: true,
         type: 'subtopic',
         tableConfig: acsDemographicTableConfig.asianSubgroup,
-        chartConfig: acsDemographicChartConfig.asianSubgroupChartConfig,
-        chartLabel: 'Percent Distribution of Asian Subgroups',
+        charts: [
+          {
+            chartConfig: acsDemographicChartConfig.asianSubgroupChartConfig,
+            chartLabel: 'Percent Distribution of Asian Subgroups',
+          },
+        ],
         children: [],
       }
     ],
   },
   {
-    id: '126',
+    id: 'acs-social',
     label: 'Social',
     selected: false,
     type: 'topic',
     children: [
       {
-        id: 'ancestry',
-        label: 'Ancestry',
+        id: 'acs-social-household-type',
+        label: 'Household Type',
         selected: false,
         type: 'subtopic',
-        tableConfig: acsSocial.ancestry,
-        chartConfig: null,
+        tableConfig: acsSocial.householdType,
+        charts: [
+          {
+            chartConfig: acsSocialChartConfig.householdTypeChartConfig,
+            chartLabel: 'Percent Distribution of Household Types',
+          },
+        ],
         children: [],
       },
       {
-        id: 'computersAndInternetUse',
-        label: 'Computers and Internet Use',
+        id: 'acs-social-relationshipToHeadOfHouseholdHouseholder',
+        label: 'Relationship To Head Of Household (Householder)',
         selected: false,
         type: 'subtopic',
-        tableConfig: acsSocial.computersAndInternetUse,
-        chartConfig: null,
+        tableConfig: acsSocial.relationshipToHeadOfHouseholdHouseholder,
+        charts: null,
         children: [],
       },
       {
-        id: 'uSCitizenshipStatus',
-        label: 'U.S. Citizenship Status',
+        id: 'acs-social-maritalStatus',
+        label: 'Marital Status',
         selected: false,
         type: 'subtopic',
-        tableConfig: acsSocial.uSCitizenshipStatus,
-        chartConfig: null,
+        tableConfig: acsSocial.maritalStatus,
+        charts: null,
         children: [],
       },
       {
-        id: 'disabilityStatusOfTheCivilianNoninstitutionalizedPopulation',
+        id: 'acs-social-grandparents',
+        label: 'Grandparents',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.grandparents,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-schoolEnrollment',
+        label: 'School Enrollment',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.schoolEnrollment,
+        charts: [
+          {
+            chartConfig: acsSocialChartConfig.schoolEnrollmentChartConfig,
+            chartLabel: 'Percent Distribution of Population 3 and Over by School Enrollment',
+          },
+        ],
+        children: [],
+      },
+      {
+        id: 'acs-social-educationalAttainmentHighestGradeCompleted',
+        label: 'Educational Attainment (Highest Grade Completed)',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.educationalAttainmentHighestGradeCompleted,
+        charts: [
+          {
+            chartConfig: acsSocialChartConfig.educationalAttainmentChartConfig,
+            chartLabel: 'Percent Distribution of Population 25 and Over by Educational Attainment',
+          },
+        ],
+        children: [],
+      },
+      {
+        id: 'acs-social-veteranStatus',
+        label: 'Veteran Status',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.veteranStatus,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-disabilityStatusOfTheCivilianNoninstitutionalizedPopulation',
         label: 'Disability Status Of The Civilian Noninstitutionalized Population',
         selected: false,
         type: 'subtopic',
         tableConfig: acsSocial.disabilityStatusOfTheCivilianNoninstitutionalizedPopulation,
-        chartConfig: null,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-residence1YearAgo',
+        label: 'Residence 1 Year Ago',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.residence1YearAgo,
+        charts: [
+          {
+            chartConfig: acsSocialChartConfig.residence1YearAgoChartConfig,
+            chartLabel: 'Percent Distribution of Population who Lived in a Different House 1 Year Ago"',
+          },
+        ],
+        children: [],
+      },
+      {
+        id: 'acs-social-placeOfBirth',
+        label: 'Place Of Birth',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.placeOfBirth,
+        charts: [
+          {
+            chartConfig: acsSocialChartConfig.placeOfBirthChartConfig,
+            chartLabel: 'Percent Distribution of Total Population by Place of Birth',
+          },
+          {
+            chartConfig: acsSocialChartConfig.foreignBornChartConfig,
+            chartLabel: 'Percent Distribution of Foreign-Born by World Region of Birth',
+          },
+        ],
+        children: [],
+      },
+      {
+        id: 'acs-social-uSCitizenshipStatus',
+        label: 'U.S. Citizenship Status',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.uSCitizenshipStatus,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-yearOfEntry',
+        label: 'Year Of Entry',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.yearOfEntry,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-languageSpokenAtHome',
+        label: 'Language Spoken At Home',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.languageSpokenAtHome,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-ancestry',
+        label: 'Ancestry',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.ancestry,
+        charts: null,
+        children: [],
+      },
+      {
+        id: 'acs-social-computersAndInternetUse',
+        label: 'Computers and Internet Use',
+        selected: false,
+        type: 'subtopic',
+        tableConfig: acsSocial.computersAndInternetUse,
+        charts: null,
         children: [],
       },
     ],


### PR DESCRIPTION
### Summary
Fills out the rest of the ACS > Social topic options. Attaches them to available charts configurations. 

Introduces new chart-config index exports for each topic folder under `chart-config/` .
The `topic-config` files will import from these chart-config index exports.

Each Topic configuration object (in `topic-config` files) will now have a `charts` attribute. It is an array of `chart` objects, which  point to the chart configuration objects and provides a chart label. 

#### Tasks/Bug Numbers
Fixes [AB#3196](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3196)

![image](https://user-images.githubusercontent.com/3311663/124180612-7052a480-da82-11eb-9061-cf9e06114f6c.png)
