### PR TITLE
3914 Configure new develop (cleanup branch) site

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -151,7 +151,11 @@ module.exports = function (environment) {
   }
 
   if (environment === 'staging') {
-    ENV.SupportServiceHost = 'https://factfinder-api.herokuapp.com';
+    ENV.SupportServiceHost = 'https://factfinder-api-develop.herokuapp.com/';
+    // TODO: Disable when we have solidified API
+    ENV['ember-cli-mirage'] = {
+      enabled: true,
+    };
   }
 
   if (environment === 'devlocal') {


### PR DESCRIPTION
Use Mirage for now.

Eventually it will connect to the new Heroku develop instance that will evenetually point to factfinder-staging DB
with WIP data.

Fixes [AB#3914](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3914)