### PR TITLE
3925 Sets up queryParams for showReliability and showCharts

### DIFF
--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -7,13 +7,15 @@ import censusTopicsDefault from '../topics-config/census';
 import acsTopicsDefault from '../topics-config/acs';
 
 export default class ExplorerController extends Controller {
-  queryParams = ['compareTo'];
+  queryParams = [
+    'compareTo',
+    'showReliability',
+    'showCharts'
+  ];
 
-  showCharts = true;
+  @tracked showCharts = true;
 
   @tracked sources = sourcesDefault;
-
-  topic = null;
 
   @tracked showReliability = false;
 
@@ -72,6 +74,15 @@ export default class ExplorerController extends Controller {
 
   @action setTopics(newTopics) {
     this.topics = newTopics;
+  }
+
+  // acceptable controlId values include: 'showReliability', 'showCharts', 'disaggregate'
+  @action toggleBooleanControl(controlId) {
+    let { [controlId]: currentControlValue } = this;
+
+    this.transitionToRoute('explorer', { queryParams: {
+      [controlId]: !currentControlValue,
+    }});
   }
 
   @action updateCompareTo(geoid) {

--- a/app/templates/components/explorer/modify-tables-menu.hbs
+++ b/app/templates/components/explorer/modify-tables-menu.hbs
@@ -23,12 +23,13 @@
         <div class="grid-x">
           <div class="cell small-2">
             <div class="switch tiny modify-tables-switch">
-              <Input
-                @id="show-reliability-switch"
-                @type="checkbox"
-                @checked={{@showReliability}}
+              <input
+                id="show-reliability-switch"
+                type="checkbox"
+                checked={{@showReliability}}
                 name="show-reliability-switch"
                 class="switch-input"
+                {{on "click" (fn @toggleBooleanControl 'showReliability')}}
               />
               <label class="switch-paddle" for="show-reliability-switch"></label>
             </div>

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -21,6 +21,7 @@
         @compareTo={{@compareTo}}
         @geoOptions={{@geoOptions}}
         @selectedGeo={{@selectedGeo}}
+        @toggleBooleanControl={{@toggleBooleanControl}}
         @updateCompareTo={{@updateCompareTo}}
       />
     </div>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -10,6 +10,7 @@
     @compareTo={{this.compareTo}}
     @geoOptions={{this.geoOptions}}
     @selectedGeo={{this.selectedGeo}}
+    @toggleBooleanControl={{this.toggleBooleanControl}}
     @updateCompareTo={{this.updateCompareTo}}
   />
 </OrangeBar>
@@ -24,12 +25,13 @@
       <div class="grid-x align-left">
         <div class="cell shrink">
           <div class="switch tiny show-charts-switch">
-            <Input
-              @id="show-charts-switch"
-              @type="checkbox"
-              @checked={{this.showCharts}}
+            <input
+              id="show-charts-switch"
+              type="checkbox"
+              checked={{this.showCharts}}
               name="show-charts-switch"
               class="switch-input"
+              {{on "click" (fn this.toggleBooleanControl 'showCharts')}}
             />
             <label class="switch-paddle" for="show-charts-switch">
             </label>


### PR DESCRIPTION
### Summary
Set up query parameters for toggling reliability data and toggling charts. Connects them to the respective UI toggles.

#### Tasks/Bug Numbers
 - Fixes [AB#3925](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3925)

### Technical Explanation
- Move from Ember `<Input />` to native HTML `<input />` to remove two-way binding on inputs.
- Passes action down from explorer controller to inputs. On input click, the action will trigger url parameter update. Url parameter state flows down to controller property state. 