### PR TITLE
2862 Set up Explorer geography summary

### DIFF
--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -72,6 +72,43 @@ export default class ExplorerController extends Controller {
     }
   }
 
+  get selectedCount() {
+    return this.model.selection.features.length;
+  }
+
+  get sortedLabels() {
+    const { features } = this.model.selection;
+
+    const bronx = features.filter(d => d.properties.borocode === '2');
+    const brooklyn = features.filter(d => d.properties.borocode === '3');
+    const manhattan = features.filter(d => d.properties.borocode === '1');
+    const queens = features.filter(d => d.properties.borocode === '4');
+    const statenisland = features.filter(d => d.properties.borocode === '5');
+
+    return [
+      {
+        label: 'Bronx',
+        features: bronx,
+      },
+      {
+        label: 'Brooklyn',
+        features: brooklyn,
+      },
+      {
+        label: 'Manhattan',
+        features: manhattan,
+      },
+      {
+        label: 'Queens',
+        features: queens,
+      },
+      {
+        label: 'Staten Island',
+        features: statenisland,
+      },
+    ];
+  }
+
   @action setTopics(newTopics) {
     this.topics = newTopics;
   }

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -33,7 +33,6 @@ export default Service.extend({
   currentMapInstance: null,
 
   selectedCount: computed('current.[]', function() {
-    console.log('is computed');
     const currentSelected = this.get('current');
     return currentSelected.features.length;
   }),

--- a/app/templates/components/select-geography-list.hbs
+++ b/app/templates/components/select-geography-list.hbs
@@ -1,9 +1,7 @@
-{{#each this.selection.sortedLabels as |boro|}}
-  {{#if boro.features.length}}
-    <strong>{{boro.label}}:</strong>
-  {{/if}}
-  {{#each boro.features as |feature|}}
-    {{feature.properties.geolabel}}
-    {{~unless (eq boro.features.lastObject.properties.geoid feature.properties.geoid) ','}}
+<ul class="comma-separated-list">
+  {{#each this.sortedLabels as |boro|}}
+    {{#if boro.features.length}}
+      <li><strong>{{boro.label}}: </strong>{{boro.features.length}}</li>
+    {{/if}}
   {{/each}}
-{{/each}}
+</ul>

--- a/app/templates/components/selection-details-text.hbs
+++ b/app/templates/components/selection-details-text.hbs
@@ -1,7 +1,7 @@
-{{this.selection.selectedCount}}
-{{if (eq this.selection.summaryLevel 'tracts') 'Census Tract'~}}
-{{if (eq this.selection.summaryLevel 'blocks') 'Census Block'~}}
-{{if (eq this.selection.summaryLevel 'ntas') 'Neighborhood'~}}
-{{if (eq this.selection.summaryLevel 'pumas') 'PUMA'~}}
-{{unless (eq this.selection.selectedCount 1) 's'}}
-{{if (eq this.selection.summaryLevel 'blocks') '(Tract Id-Block Id)'~}}
+{{@selectedCount}}
+{{if (eq @selectedType 'tracts') 'Census Tract'~}}
+{{if (eq @selectedType 'blocks') 'Census Block'~}}
+{{if (eq @selectedType 'ntas') 'Neighborhood'~}}
+{{if (eq @selectedType 'pumas') 'PUMA'~}}
+{{unless (eq @selectedCount 1) 's'}}
+{{if (eq @selectedType 'blocks') '(Tract Id-Block Id)'~}}

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -23,6 +23,24 @@
       Your Data:
     </h1>
 
+    <div class="grid-container fluid profile-geographies ">
+      <div class="grid-x align-left">
+        <h3 class="profile-geographies-header">
+          <SelectionDetailsText
+            @selectedCount={{this.selectedCount}}
+            @selectedType={{@model.selection.type}}
+          />
+        </h3>
+        <span class="dark-gray">&nbsp;|&nbsp;</span>
+
+        <p class="profile-geographies-list">
+          <SelectGeographyList
+            @sortedLabels={{this.sortedLabels}}
+          />
+        </p>
+      </div>
+    </div>
+
     <div class="grid-container fluid">
       <div class="grid-x align-left">
         <div class="cell shrink">


### PR DESCRIPTION
### Technical Summary
- Reworks old geography summary components and integrates them with new state flow.
Instead of depending on old selection service, they compute off of the upstream selection model.
The relevant selection service computed properties have been moved to the explorer controller. 

- Reworks HTML formatting

TODO: Need to verify that the selection model `type` property is reliable for different geographies.
Current static data provides the `ntas` value for `type`. It should also provide other values like `tracts`, `blocks`, `pumas` etc. 

#### Tasks/Bug Numbers
 - Fixes [AB#2862](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2862)
