### PR TITLE
3961 QueryParam for selected source

### DIFF
--- a/app/components/explorer/source-select-dropdown.js
+++ b/app/components/explorer/source-select-dropdown.js
@@ -2,6 +2,11 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+/**
+  * @param { fn(Source POJO) } setSource - (Required) Ember Action function that accepts a Source POJO. It will
+  * set the selected Explorer source to the passed Source.
+  * @param { [] } sources - array of Source objects
+*/
 export default class SourceSelectDropdownComponent extends Component {
   @tracked open = false;
 
@@ -19,27 +24,5 @@ export default class SourceSelectDropdownComponent extends Component {
 
   get acsSources() {
     return this.args.sources.filter(source => source.type === 'acs');
-  }
-
-  toggleSourceInList = (sources, sourceId) => {
-    return sources.map((source) => {
-      if (source.id === sourceId) {
-        return {
-          ...source,
-          selected: true,
-        };
-      }
-
-      return {
-        ...source,
-        selected: false,
-      }
-    });
-  }
-
-  @action onSourceToggle(sourceId) {
-    const newSources = this.toggleSourceInList(this.args.sources, sourceId);
-
-    this.args.setSources(newSources);
   }
 }

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -8,6 +8,9 @@ import acsTopicsDefault from '../topics-config/acs';
 
 export default class ExplorerController extends Controller {
   queryParams = [
+    {
+      sourceId: 'source',
+    },
     'compareTo',
     'showReliability',
     'showCharts'
@@ -15,7 +18,7 @@ export default class ExplorerController extends Controller {
 
   @tracked showCharts = true;
 
-  @tracked sources = sourcesDefault;
+  @tracked sourceId = 'decennial-2020';
 
   @tracked showReliability = false;
 
@@ -31,6 +34,22 @@ export default class ExplorerController extends Controller {
 
   @tracked geoOptions = null;
 
+  toggleSourceInList(sourceId) {
+    return sourcesDefault.map((source) => {
+      if (source.id === sourceId) {
+        return {
+          ...source,
+          selected: true,
+        };
+      }
+
+      return {
+        ...source,
+        selected: false,
+      }
+    });
+  }
+
   get selectedGeo() {
     if (this.geoOptions) {
       return this.geoOptions.findBy('geoid', this.compareTo);
@@ -39,8 +58,22 @@ export default class ExplorerController extends Controller {
     return null;
   }
 
+  get sources() {
+    if (this.sourceId) {
+      return this.toggleSourceInList(this.sourceId);
+    }
+
+    return sourcesDefault;
+  }
+
   get source() {
     return this.sources.find(source => source.selected);
+  }
+
+  set source(newSource) {
+    const { id } = newSource;
+
+    this.transitionToRoute('explorer', { queryParams: { source: id }});
   }
 
   // returns either 'current' or 'change'
@@ -48,10 +81,6 @@ export default class ExplorerController extends Controller {
     if (this.source.changeOverTime) return 'change';
 
     return 'current';
-  }
-
-  @action setSources(newSources) {
-    this.sources = newSources;
   }
 
   get topics() {
@@ -107,6 +136,10 @@ export default class ExplorerController extends Controller {
         features: statenisland,
       },
     ];
+  }
+
+  @action setSource(newSource) {
+    this.source = newSource;
   }
 
   @action setTopics(newTopics) {

--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -25,7 +25,7 @@
       {{#each this.censusSources key="id" as |source|}}
         <div
           class="nestable-list-item grid-x clickable"
-          {{on "click" (fn this.onSourceToggle source.id)}}
+          {{on "click" (fn @setSource source)}}
         >
           <div class="cell small-1">
             <span class="dcp-orange">
@@ -47,7 +47,7 @@
       {{#each this.acsSources key="id" as |source|}}
         <div
           class="nestable-list-item grid-x clickable"
-          {{on "click" (fn this.onSourceToggle source.id)}}
+          {{on "click" (fn @setSource source)}}
         >
           <div class="cell small-1">
             <span class="dcp-orange">

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -6,7 +6,7 @@
     <div class="cell small-10 text-left">
       <Explorer::SourceSelectDropdown
         @sources={{@sources}}
-        @setSources={{@setSources}}
+        @setSource={{@setSource}}
       />
 
       <Explorer::TopicSelectDropdown

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -4,7 +4,7 @@
     @topics={{this.topics}}
     @setTopics={{this.setTopics}}
     @sources={{this.sources}}
-    @setSources={{this.setSources}}
+    @setSource={{this.setSource}}
     @showReliability={{this.showReliability}}
     @disaggregate={{this.disaggregate}}
     @compareTo={{this.compareTo}}


### PR DESCRIPTION
### Summary
Source state is now held by a URL  query parameter. Allows users to copy URL to preserve selected state. 

![image](https://user-images.githubusercontent.com/3311663/125865470-ade5c605-ece7-4162-9b90-c70f900d1a5c.png)
![image](https://user-images.githubusercontent.com/3311663/125865481-69837710-1f86-437b-8d3a-8fde67aa8ab5.png)


#### Tasks/Bug Numbers
 - Fixes [AB#3961](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3961)

### Technical Summary
  - Controller and Component actions no longer modify the `sources` array directly. Instead, they update the `source` URL query parameter.
  - The `source` query param value should be one of the `id` property values seen in `sources-config/index.js` 
  - Actions shall now update the source QueryParam by "Setting" the `source` property. There is a new setter for the `source` property which triggers the queryParam update.
  - The `source` URL parameter actually maps to a `sourceId` string property, since the Explorer controller `source` represents a full Source POJO.  
  - The sources list is now computed off of the `sourceId` property. It will return a list of Sources in which the Source object that has id `sourceId` is marked as "selected". 
