### PR TITLE
Fix Data Download menu positioning

### DIFF
--- a/app/styles/modules/components/explorer/download-data-dropdown.scss
+++ b/app/styles/modules/components/explorer/download-data-dropdown.scss
@@ -18,6 +18,7 @@ $download-data-dropdown-hover-color: rgba($dark-gray,0.08);
   border: 1px solid $silver;
   transition: all 0.2s;
   border-radius: 10px;
+  text-align: center;
   p {
     line-height: 1;
   }
@@ -32,10 +33,11 @@ $download-data-dropdown-hover-color: rgba($dark-gray,0.08);
       min-height: 0;
     }
   }
+
   .triangle {
     position: absolute;
     top: -15px;
-    left: 175px;
+    right: 125px;
     width: 0;
     height: 0;
     border-left: 15px solid transparent;

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -3,7 +3,7 @@
   class="grid-container fluid"
 >
   <div class="grid-x grid-margin-x">
-    <div class="cell small-10 text-left">
+    <div class="cell shrink text-left">
       <Explorer::SourceSelectDropdown
         @sources={{@sources}}
         @setSource={{@setSource}}
@@ -27,13 +27,15 @@
       />
     </div>
 
-    <div class="bar-item">
-      <Explorer::DownloadDataDropdown
-        @topics={{@topics}}
-        @sources={{@sources}}
-        @showReliability={{@showReliability}}
-        @toggleReliability={{@toggleReliability}}
-      />
+    <div class="cell auto text-right">
+      <div class="bar-item">
+        <Explorer::DownloadDataDropdown
+          @topics={{@topics}}
+          @sources={{@sources}}
+          @showReliability={{@showReliability}}
+          @toggleReliability={{@toggleReliability}}
+        />
+      </div>
     </div>
 
   </div>


### PR DESCRIPTION
- Prevents data download button from jumping to next line (when window was still medium - large)
- Centers the menu triangle relative to the button. 
Now:
![image](https://user-images.githubusercontent.com/3311663/126361140-200c8750-4080-441f-97bc-5c814f32ea37.png)
Previously:
![image](https://user-images.githubusercontent.com/3311663/126361331-1f263f88-b4d8-4b3a-9091-a7d6fcf45f58.png)
