### PR TITLE
4087 4088 dynamic selected topic in download dropdown

### DIFF
--- a/app/components/explorer/download-data-dropdown.js
+++ b/app/components/explorer/download-data-dropdown.js
@@ -109,11 +109,11 @@ export default class DownloadDataDropdown extends Component{
 
   get numSelected() {
     return this.args.topics.reduce((prev, cur) => {
-        if (cur.type === 'subtopic' && cur.selected) {
+        if (cur.type === 'subtopic' && (cur.selected === "selected")) {
           return prev += 1;
         }
 
-        return prev += cur.children.filter((child) => child.selected).length;
+        return prev += cur.children.filter((child) => (child.selected === "selected")).length;
       }, 0);
   }
   

--- a/app/components/explorer/download-data-dropdown.js
+++ b/app/components/explorer/download-data-dropdown.js
@@ -125,7 +125,7 @@ export default class DownloadDataDropdown extends Component{
     var list = this.args.topics.map(topic => {
       return {
         label: topic.label,
-        children: topic.children.filter(subtopic => subtopic.selected)
+        children: topic.children.filter((subtopic) => (subtopic.selected === "selected"))
       }
     })
     return list.filter(topiary => topiary.children.length > 0);

--- a/app/templates/components/explorer/download-data-dropdown.hbs
+++ b/app/templates/components/explorer/download-data-dropdown.hbs
@@ -36,7 +36,7 @@
         {{/each}}
       {{else}}
         {{#each @topics as |topic|}}
-          {{#if topic.selected}}
+          {{#if (eq topic.selected 'selected')}}
             <p>{{topic.label}}</p>
           {{/if}}
         {{/each}}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This fixes the indicator of the number of selected topics, and the list of selected topics shown in the download drop-down menu.

#### Tasks/Bug Numbers
 - Fixes [AB#4087](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4087)
 - Fixes [AB#4088](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4088)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
