### PR TITLE
3142, 3148 - add new summary levels and rework search

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -156,13 +156,11 @@ export default Controller.extend({
     const selection = this.get('selection');
 
     if (!this.get('isDrawing')) {
-      console.log(feature);
       selection.handleSelectedFeatures([feature]);
     }
   },
 
   handleDrawCreate(e) {
-    console.log('did create');
     // delete the drawn geometry
     draw.deleteAll();
 

--- a/app/layer-groups/boroughs.js
+++ b/app/layer-groups/boroughs.js
@@ -15,24 +15,6 @@ export default {
       },
       highlightable: true,
     },
-    // {
-    //   layer: {
-    //     id: 'boroughs-line-glow',
-    //     type: 'line',
-    //     source: 'census-geoms',
-    //     'source-layer': 'census-geoms-blocks',
-    //     paint: {
-    //       'line-color': '#76CAF5',
-    //       'line-opacity': 0.2,
-    //       'line-width': {
-    //         stops: [
-    //           [11, 3],
-    //           [16, 6],
-    //         ],
-    //       },
-    //     },
-    //   },
-    // },
     {
       layer: {
         id: 'boroughs-line',

--- a/app/layer-groups/boroughs.js
+++ b/app/layer-groups/boroughs.js
@@ -1,0 +1,112 @@
+export default {
+  id: 'boroughs',
+  title: 'Boroughs',
+  visible: true,
+  layers: [
+    {
+      layer: {
+        id: 'boroughs-fill',
+        type: 'fill',
+        source: 'census-admin-boundaries',
+        'source-layer': 'boroughs',
+        paint: {
+          'fill-opacity': 0.01,
+        },
+      },
+      highlightable: true,
+    },
+    // {
+    //   layer: {
+    //     id: 'boroughs-line-glow',
+    //     type: 'line',
+    //     source: 'census-geoms',
+    //     'source-layer': 'census-geoms-blocks',
+    //     paint: {
+    //       'line-color': '#76CAF5',
+    //       'line-opacity': 0.2,
+    //       'line-width': {
+    //         stops: [
+    //           [11, 3],
+    //           [16, 6],
+    //         ],
+    //       },
+    //     },
+    //   },
+    // },
+    {
+      layer: {
+        id: 'boroughs-line',
+        type: 'line',
+        source: 'census-admin-boundaries',
+        'source-layer': 'boroughs',
+        paint: {
+          'line-color': '#444',
+          'line-opacity': 0.5,
+          'line-width': {
+            stops: [
+              [
+                11,
+                0.5,
+              ],
+              [
+                16,
+                1,
+              ],
+            ],
+          },
+        },
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round',
+        },
+      },
+    },
+    {
+      layer: {
+        id: 'boroughs-label',
+        type: 'symbol',
+        source: 'census-admin-boundaries',
+        'source-layer': 'boroughs',
+        minzoom: 13,
+        layout: {
+          'text-field': '{boroname}',
+          'text-font': [
+            'Open Sans Semibold',
+            'Arial Unicode MS Bold',
+          ],
+          'text-size': {
+            stops: [
+              [
+                13,
+                6,
+              ],
+              [
+                17,
+                16,
+              ],
+            ],
+          },
+
+        },
+        paint: {
+          'text-color': '#626262',
+          'text-halo-color': '#FFFFFF',
+          'text-halo-width': 2,
+          'text-halo-blur': 2,
+          'text-opacity': {
+            stops: [
+              [
+                13,
+                0,
+              ],
+              [
+                14,
+                1,
+              ],
+            ],
+          },
+        },
+      },
+    },
+  ],
+};

--- a/app/layer-groups/cdtas.js
+++ b/app/layer-groups/cdtas.js
@@ -1,0 +1,112 @@
+export default {
+  id: 'cdtas',
+  title: 'CDTAs',
+  visible: true,
+  layers: [
+    {
+      layer: {
+        id: 'cdtas-fill',
+        type: 'fill',
+        source: 'census-admin-boundaries',
+        'source-layer': 'cdtas',
+        paint: {
+          'fill-opacity': 0.01,
+        },
+      },
+      highlightable: true,
+    },
+    // {
+    //   layer: {
+    //     id: 'cdtas-line-glow',
+    //     type: 'line',
+    //     source: 'census-geoms',
+    //     'source-layer': 'census-geoms-blocks',
+    //     paint: {
+    //       'line-color': '#76CAF5',
+    //       'line-opacity': 0.2,
+    //       'line-width': {
+    //         stops: [
+    //           [11, 3],
+    //           [16, 6],
+    //         ],
+    //       },
+    //     },
+    //   },
+    // },
+    {
+      layer: {
+        id: 'cdtas-line',
+        type: 'line',
+        source: 'census-admin-boundaries',
+        'source-layer': 'cdtas',
+        paint: {
+          'line-color': '#444',
+          'line-opacity': 0.5,
+          'line-width': {
+            stops: [
+              [
+                11,
+                0.5,
+              ],
+              [
+                16,
+                1,
+              ],
+            ],
+          },
+        },
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round',
+        },
+      },
+    },
+    {
+      layer: {
+        id: 'cdtas-label',
+        type: 'symbol',
+        source: 'census-admin-boundaries',
+        'source-layer': 'cdtas',
+        minzoom: 13,
+        layout: {
+          'text-field': '{cdta2020}',
+          'text-font': [
+            'Open Sans Semibold',
+            'Arial Unicode MS Bold',
+          ],
+          'text-size': {
+            stops: [
+              [
+                13,
+                6,
+              ],
+              [
+                17,
+                16,
+              ],
+            ],
+          },
+
+        },
+        paint: {
+          'text-color': '#626262',
+          'text-halo-color': '#FFFFFF',
+          'text-halo-width': 2,
+          'text-halo-blur': 2,
+          'text-opacity': {
+            stops: [
+              [
+                13,
+                0,
+              ],
+              [
+                14,
+                1,
+              ],
+            ],
+          },
+        },
+      },
+    },
+  ],
+};

--- a/app/layer-groups/cdtas.js
+++ b/app/layer-groups/cdtas.js
@@ -15,24 +15,6 @@ export default {
       },
       highlightable: true,
     },
-    // {
-    //   layer: {
-    //     id: 'cdtas-line-glow',
-    //     type: 'line',
-    //     source: 'census-geoms',
-    //     'source-layer': 'census-geoms-blocks',
-    //     paint: {
-    //       'line-color': '#76CAF5',
-    //       'line-opacity': 0.2,
-    //       'line-width': {
-    //         stops: [
-    //           [11, 3],
-    //           [16, 6],
-    //         ],
-    //       },
-    //     },
-    //   },
-    // },
     {
       layer: {
         id: 'cdtas-line',

--- a/app/layer-groups/census-blocks.js
+++ b/app/layer-groups/census-blocks.js
@@ -15,24 +15,6 @@ export default {
       },
       highlightable: true,
     },
-    // {
-    //   layer: {
-    //     id: 'census-blocks-line-glow',
-    //     type: 'line',
-    //     source: 'census-geoms',
-    //     'source-layer': 'census-geoms-blocks',
-    //     paint: {
-    //       'line-color': '#76CAF5',
-    //       'line-opacity': 0.2,
-    //       'line-width': {
-    //         stops: [
-    //           [11, 3],
-    //           [16, 6],
-    //         ],
-    //       },
-    //     },
-    //   },
-    // },
     {
       layer: {
         id: 'census-blocks-line',

--- a/app/layer-groups/cities.js
+++ b/app/layer-groups/cities.js
@@ -1,0 +1,112 @@
+export default {
+  id: 'cities',
+  title: 'Cities',
+  visible: true,
+  layers: [
+    {
+      layer: {
+        id: 'cities-fill',
+        type: 'fill',
+        source: 'census-admin-boundaries',
+        'source-layer': 'cities',
+        paint: {
+          'fill-opacity': 0.01,
+        },
+      },
+      highlightable: true,
+    },
+    // {
+    //   layer: {
+    //     id: 'cities-line-glow',
+    //     type: 'line',
+    //     source: 'census-geoms',
+    //     'source-layer': 'census-geoms-blocks',
+    //     paint: {
+    //       'line-color': '#76CAF5',
+    //       'line-opacity': 0.2,
+    //       'line-width': {
+    //         stops: [
+    //           [11, 3],
+    //           [16, 6],
+    //         ],
+    //       },
+    //     },
+    //   },
+    // },
+    {
+      layer: {
+        id: 'cities-line',
+        type: 'line',
+        source: 'census-admin-boundaries',
+        'source-layer': 'cities',
+        paint: {
+          'line-color': '#444',
+          'line-opacity': 0.5,
+          'line-width': {
+            stops: [
+              [
+                11,
+                0.5,
+              ],
+              [
+                16,
+                1,
+              ],
+            ],
+          },
+        },
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round',
+        },
+      },
+    },
+    {
+      layer: {
+        id: 'cities-label',
+        type: 'symbol',
+        source: 'census-admin-boundaries',
+        'source-layer': 'cities',
+        minzoom: 13,
+        layout: {
+          'text-field': '{boroname}',
+          'text-font': [
+            'Open Sans Semibold',
+            'Arial Unicode MS Bold',
+          ],
+          'text-size': {
+            stops: [
+              [
+                13,
+                6,
+              ],
+              [
+                17,
+                16,
+              ],
+            ],
+          },
+
+        },
+        paint: {
+          'text-color': '#626262',
+          'text-halo-color': '#FFFFFF',
+          'text-halo-width': 2,
+          'text-halo-blur': 2,
+          'text-opacity': {
+            stops: [
+              [
+                13,
+                0,
+              ],
+              [
+                14,
+                1,
+              ],
+            ],
+          },
+        },
+      },
+    },
+  ],
+};

--- a/app/layer-groups/cities.js
+++ b/app/layer-groups/cities.js
@@ -15,24 +15,6 @@ export default {
       },
       highlightable: true,
     },
-    // {
-    //   layer: {
-    //     id: 'cities-line-glow',
-    //     type: 'line',
-    //     source: 'census-geoms',
-    //     'source-layer': 'census-geoms-blocks',
-    //     paint: {
-    //       'line-color': '#76CAF5',
-    //       'line-opacity': 0.2,
-    //       'line-width': {
-    //         stops: [
-    //           [11, 3],
-    //           [16, 6],
-    //         ],
-    //       },
-    //     },
-    //   },
-    // },
     {
       layer: {
         id: 'cities-line',

--- a/app/layer-groups/districts.js
+++ b/app/layer-groups/districts.js
@@ -1,0 +1,112 @@
+export default {
+  id: 'districts',
+  title: 'Community Districts',
+  visible: true,
+  layers: [
+    {
+      layer: {
+        id: 'districts-fill',
+        type: 'fill',
+        source: 'census-admin-boundaries',
+        'source-layer': 'districts',
+        paint: {
+          'fill-opacity': 0.01,
+        },
+      },
+      highlightable: true,
+    },
+    // {
+    //   layer: {
+    //     id: 'districts-line-glow',
+    //     type: 'line',
+    //     source: 'census-geoms',
+    //     'source-layer': 'census-geoms-blocks',
+    //     paint: {
+    //       'line-color': '#76CAF5',
+    //       'line-opacity': 0.2,
+    //       'line-width': {
+    //         stops: [
+    //           [11, 3],
+    //           [16, 6],
+    //         ],
+    //       },
+    //     },
+    //   },
+    // },
+    {
+      layer: {
+        id: 'districts-line',
+        type: 'line',
+        source: 'census-admin-boundaries',
+        'source-layer': 'districts',
+        paint: {
+          'line-color': '#444',
+          'line-opacity': 0.5,
+          'line-width': {
+            stops: [
+              [
+                11,
+                0.5,
+              ],
+              [
+                16,
+                1,
+              ],
+            ],
+          },
+        },
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round',
+        },
+      },
+    },
+    {
+      layer: {
+        id: 'districts-label',
+        type: 'symbol',
+        source: 'census-admin-boundaries',
+        'source-layer': 'districts',
+        minzoom: 13,
+        layout: {
+          'text-field': '{borocd}',
+          'text-font': [
+            'Open Sans Semibold',
+            'Arial Unicode MS Bold',
+          ],
+          'text-size': {
+            stops: [
+              [
+                13,
+                6,
+              ],
+              [
+                17,
+                16,
+              ],
+            ],
+          },
+
+        },
+        paint: {
+          'text-color': '#626262',
+          'text-halo-color': '#FFFFFF',
+          'text-halo-width': 2,
+          'text-halo-blur': 2,
+          'text-opacity': {
+            stops: [
+              [
+                13,
+                0,
+              ],
+              [
+                14,
+                1,
+              ],
+            ],
+          },
+        },
+      },
+    },
+  ],
+};

--- a/app/layer-groups/districts.js
+++ b/app/layer-groups/districts.js
@@ -15,24 +15,6 @@ export default {
       },
       highlightable: true,
     },
-    // {
-    //   layer: {
-    //     id: 'districts-line-glow',
-    //     type: 'line',
-    //     source: 'census-geoms',
-    //     'source-layer': 'census-geoms-blocks',
-    //     paint: {
-    //       'line-color': '#76CAF5',
-    //       'line-opacity': 0.2,
-    //       'line-width': {
-    //         stops: [
-    //           [11, 3],
-    //           [16, 6],
-    //         ],
-    //       },
-    //     },
-    //   },
-    // },
     {
       layer: {
         id: 'districts-line',

--- a/app/layer-groups/index.js
+++ b/app/layer-groups/index.js
@@ -5,6 +5,7 @@ import nycPumasSelection from './nyc-pumas-selection';
 import cdtasSelection from './cdtas';
 import districtsSelection from './districts';
 import boroughsSelection from './boroughs';
+import citiesSelection from './cities';
 
 
 export default {
@@ -15,4 +16,5 @@ export default {
   cdtasSelection,
   districtsSelection,
   boroughsSelection,
+  citiesSelection,
 };

--- a/app/layer-groups/index.js
+++ b/app/layer-groups/index.js
@@ -2,6 +2,9 @@ import censusBlocks from './census-blocks';
 import choropleths from './choropleths';
 import neighborhoodTabulationAreasSelection from './neighborhood-tabulation-areas-selection';
 import nycPumasSelection from './nyc-pumas-selection';
+import cdtasSelection from './cdtas';
+import districtsSelection from './districts';
+import boroughsSelection from './boroughs';
 
 
 export default {
@@ -9,4 +12,7 @@ export default {
   choropleths,
   neighborhoodTabulationAreasSelection,
   nycPumasSelection,
+  cdtasSelection,
+  districtsSelection,
+  boroughsSelection,
 };

--- a/app/queries/summary-levels.js
+++ b/app/queries/summary-levels.js
@@ -23,6 +23,38 @@ export default {
     FROM nyc_census_tracts
   `,
 
+  cdtas: (webmercator = true) => `
+    SELECT
+      ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
+      the_geom,
+      cdtaname as geolabel,
+      cdta2020,
+      cdtatype,
+      boroname,
+      cdta2020 AS geoid
+    FROM nycdta2020
+  `,
+
+  districts: (webmercator = true) => `
+    SELECT
+      ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
+      the_geom,
+      cd_short_title as geolabel,
+      boroname,
+      borocd AS geoid
+    FROM cd_boundaries_v0_dh
+  `,
+
+  boroughs: (webmercator = true) => `
+    SELECT
+      ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
+      the_geom,
+      boroname as geolabel,
+      boroname,
+      borocode AS geoid
+    FROM dcp_borough_boundary
+  `,
+
   ntas: (webmercator = true) => `
     SELECT
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},

--- a/app/queries/summary-levels.js
+++ b/app/queries/summary-levels.js
@@ -55,6 +55,15 @@ export default {
     FROM dcp_borough_boundary
   `,
 
+  cities: (webmercator = true) => `
+    SELECT
+      ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
+      the_geom,
+      'New York City' as geolabel,
+      id AS geoid
+    FROM nyc2020_sw_unofficial
+  `,
+
   ntas: (webmercator = true) => `
     SELECT
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -49,6 +49,7 @@ export default Route.extend({
         { id: 'factfinder--census-tracts', visible: false },
         { id: 'factfinder--cdtas', visible: false },
         { id: 'factfinder--districts', visible: false },
+        { id: 'factfinder--boroughs', visible: false },
         { id: 'factfinder--ntas', visible: false },
         { id: 'factfinder--pumas', visible: false },
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -50,6 +50,7 @@ export default Route.extend({
         { id: 'factfinder--cdtas', visible: false },
         { id: 'factfinder--districts', visible: false },
         { id: 'factfinder--boroughs', visible: false },
+        { id: 'factfinder--cities', visible: false },
         { id: 'factfinder--ntas', visible: false },
         { id: 'factfinder--pumas', visible: false },
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -38,7 +38,7 @@ export default Route.extend({
         // Administrative Boundaries
         // { id: 'assembly-districts', visible: false },
         // { id: 'ny-senate-districts', visible: false },
-        // { id: 'boroughs', visible: false },
+        { id: 'boroughs', visible: false },
         { id: 'nyc-council-districts', visible: false },
         { id: 'nyc-pumas', visible: false },
         { id: 'community-districts', visible: false },
@@ -47,6 +47,8 @@ export default Route.extend({
         // Census selection groups
         { id: 'factfinder--census-blocks', visible: false },
         { id: 'factfinder--census-tracts', visible: false },
+        { id: 'factfinder--cdtas', visible: false },
+        { id: 'factfinder--districts', visible: false },
         { id: 'factfinder--ntas', visible: false },
         { id: 'factfinder--pumas', visible: false },
 

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -12,6 +12,9 @@ const EMPTY_GEOJSON = { type: 'FeatureCollection', features: [] };
 const SUM_LEVEL_DICT = {
   blocks: { sql: summaryLevelQueries.blocks(false), tracts: 'boroct2010' },
   tracts: { sql: summaryLevelQueries.tracts(false), ntas: 'ntacode', blocks: 'boroct2010' },
+  cdtas: { sql: summaryLevelQueries.cdtas(false), cdtas: 'cdta2020' },
+  districts: { sql: summaryLevelQueries.districts(false), districts: 'borocd' },
+  boroughs: { sql: summaryLevelQueries.boroughs(false), boroughs: 'borocode' },
   ntas: { sql: summaryLevelQueries.ntas(false), tracts: 'ntacode' },
   pumas: { sql: summaryLevelQueries.pumas(false) },
 };
@@ -99,7 +102,6 @@ export default Service.extend({
   // methods
   handleSummaryLevelToggle(toLevel) {
     const fromLevel = this.get('summaryLevel');
-
     this.set('summaryLevel', toLevel);
 
     const layerGroupIdMap = (level) => {
@@ -108,8 +110,14 @@ export default Service.extend({
           return 'factfinder--census-tracts';
         case 'blocks':
           return 'factfinder--census-blocks';
+        case 'cdtas':
+          return 'factfinder--cdtas';
+        case 'districts':
+          return 'factfinder--districts';
         case 'ntas':
           return 'factfinder--ntas';
+        case 'boroughs':
+          return 'factfinder--boroughs';
         case 'pumas':
           return 'factfinder--pumas';
         default:

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -15,6 +15,7 @@ const SUM_LEVEL_DICT = {
   cdtas: { sql: summaryLevelQueries.cdtas(false), cdtas: 'cdta2020' },
   districts: { sql: summaryLevelQueries.districts(false), districts: 'borocd' },
   boroughs: { sql: summaryLevelQueries.boroughs(false), boroughs: 'borocode' },
+  cities: { sql: summaryLevelQueries.cities(false), cities: 'id' },
   ntas: { sql: summaryLevelQueries.ntas(false), tracts: 'ntacode' },
   pumas: { sql: summaryLevelQueries.pumas(false) },
 };
@@ -118,6 +119,8 @@ export default Service.extend({
           return 'factfinder--ntas';
         case 'boroughs':
           return 'factfinder--boroughs';
+        case 'cities':
+          return 'factfinder--cities';
         case 'pumas':
           return 'factfinder--pumas';
         default:

--- a/app/sources/census-admin-boundaries.js
+++ b/app/sources/census-admin-boundaries.js
@@ -34,6 +34,11 @@ export default {
     },
 
     {
+      id: 'cities',
+      sql: 'SELECT the_geom_webmercator, "New York City" AS geolabel, id AS geoid FROM nyc2020_sw_unofficial',
+    },
+
+    {
       id: 'nyc-pumas',
       sql: 'SELECT the_geom_webmercator, puma AS geolabel, puma AS geoid FROM nyc_puma',
     },

--- a/app/sources/census-admin-boundaries.js
+++ b/app/sources/census-admin-boundaries.js
@@ -18,6 +18,22 @@ export default {
     },
 
     {
+      id: 'cdtas',
+      sql: 'SELECT the_geom_webmercator, cdtaname AS geolabel, cdta2020 AS geoid FROM nycdta2020',
+    },
+
+
+    {
+      id: 'districts',
+      sql: 'SELECT the_geom_webmercator, cd_short_title AS geolabel, borocd AS geoid FROM cd_boundaries_v0_dh',
+    },
+
+    {
+      id: 'boroughs',
+      sql: 'SELECT the_geom_webmercator, boroname AS geolabel, borocode AS geoid FROM cd_boundaries_v0_dh',
+    },
+
+    {
       id: 'nyc-pumas',
       sql: 'SELECT the_geom_webmercator, puma AS geolabel, puma AS geoid FROM nyc_puma',
     },

--- a/app/styles/modules/_m-orange-bar.scss
+++ b/app/styles/modules/_m-orange-bar.scss
@@ -34,7 +34,7 @@
     border-right: 1px solid $white;
   }
 
-  .dropdown-content a {
+  .dropdown-content a, .dropdown-content li {
     box-shadow: 0 0 0 2px $white;
 
     &:last-child {
@@ -51,7 +51,7 @@
       padding-left: 0.75rem;
     }
   }
-  li:hover, li:active, a:hover, a:active, .dropdown:hover .dropbtn {
+  li:hover, li:active, a:hover, a:active, a.active, .dropdown:hover .dropbtn {
     background-color: $white;
     color: #d96b27;
   }

--- a/app/styles/modules/_m-search.scss
+++ b/app/styles/modules/_m-search.scss
@@ -30,6 +30,8 @@
 .search-results {
   z-index: 5;
   background-color: rgba($white,0.94);
+  color: $black;
+  text-align: left;
   font-size: rem-calc(12);
   width: 100%;
   position: absolute;

--- a/app/templates/components/map-search.hbs
+++ b/app/templates/components/map-search.hbs
@@ -17,13 +17,13 @@
   {{#each-in (group-by "type" this.results.value) as |type rows|}}
     <li>
       {{#if (eq type 'block')}}
-        <h4 class="header-small results-header">2010 Census Blocks</h4>
+        <h4 class="header-small results-header">2020 Census Blocks</h4>
       {{else if (eq type 'tract')}}
-        <h4 class="header-small results-header">2010 Census Tracts</h4>
+        <h4 class="header-small results-header">2020 Census Tracts</h4>
       {{else if (eq type 'nta')}}
         <h4 class="header-small results-header">Neighborhoods</h4>
-      {{else if (eq type 'puma')}}
-        <h4 class="header-small results-header">PUMAs</h4>
+      {{else if (eq type 'district')}}
+        <h4 class="header-small results-header">Community Districts</h4>
       {{else}}
         <h4 class="header-small results-header">Add Map Pin</h4>
       {{/if}}
@@ -36,7 +36,7 @@
           <span class="icon polygon"></span>
         {{else if (eq type 'nta')}}
           <span class="icon polygon large"></span>
-        {{else if (eq type 'puma')}}
+        {{else if (eq type 'district')}}
           <span class="icon polygon large"></span>
         {{else}}
           {{fa-icon icon="map-pin"}}

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -66,7 +66,7 @@
                 <div class="dropdown-content">
                   <a href="#" class="{{if (eq this.selection.summaryLevel 'blocks') 'active'}} explode-block" data-test-toggle-blocks {{action this.handleSummaryLevelToggle 'blocks'}}>Census Block{{ember-tooltip delay=500 text='Create selection area using census blocks'}}</a>
                   <a href="#" class="{{if (eq this.selection.summaryLevel 'boroughs') 'active'}} explode-borough" data-test-toggle-boroughs {{action this.handleSummaryLevelToggle 'boroughs'}}>Borough{{ember-tooltip delay=500 text='Create selection area using boroughs'}}</a>
-                  <a href="#">New York City</a>
+                  <a href="#" class="{{if (eq this.selection.summaryLevel 'cities') 'active'}} explode-city" data-test-toggle-cities {{action this.handleSummaryLevelToggle 'cities'}}>New York City{{ember-tooltip delay=500 text='Create selection area using New York CIty'}}</a>
                 </div>
               </div>
             </li>

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -63,11 +63,23 @@
             <li class="dropdown explode-moregeos">
               <a href="#" class="dropbtn dropbtn-centered">More Geographies</a>
               <div class="dropsizer">
-                <div class="dropdown-content">
-                  <a href="#">Census Block</a>
+                <ul class="dropdown-content">
+                  <li class="{{if (eq this.selection.summaryLevel 'blocks') 'active'}} explode-block">
+                    <a href="#" data-test-toggle-blocks {{action this.handleSummaryLevelToggle 'blocks'}}>Census Block</a>
+                    {{ember-tooltip delay=500 text='Create selection area using census blocks'}}
+                  </li>
+                  <li class="{{if (eq this.selection.summaryLevel 'boroughs') 'active'}} explode-borough">
+                    <a href="#" data-test-toggle-boroughs {{action this.handleSummaryLevelToggle 'boroughs'}}>Borough</a>
+                    {{ember-tooltip delay=500 text='Create selection area using boroughs'}}
+                  </li>
+                  <li class="{{if (eq this.selection.summaryLevel 'boroughs') 'active'}} explode-borough">
+                    <a href="#" data-test-toggle-boroughs {{action this.handleSummaryLevelToggle 'boroughs'}}>Borough</a>
+                    {{ember-tooltip delay=500 text='Create selection area using boroughs'}}
+                  </li>
+                  {{!-- <a href="#">Census Block</a>
                   <a href="#">Borough</a>
-                  <a href="#">New York City</a>
-                </div>
+                  <a href="#">New York City</a> --}}
+                </ul>
               </div>
             </li>
           </ul>

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -63,30 +63,17 @@
             <li class="dropdown explode-moregeos">
               <a href="#" class="dropbtn dropbtn-centered">More Geographies</a>
               <div class="dropsizer">
-                <ul class="dropdown-content">
-                  <li class="{{if (eq this.selection.summaryLevel 'blocks') 'active'}} explode-block">
-                    <a href="#" data-test-toggle-blocks {{action this.handleSummaryLevelToggle 'blocks'}}>Census Block</a>
-                    {{ember-tooltip delay=500 text='Create selection area using census blocks'}}
-                  </li>
-                  <li class="{{if (eq this.selection.summaryLevel 'boroughs') 'active'}} explode-borough">
-                    <a href="#" data-test-toggle-boroughs {{action this.handleSummaryLevelToggle 'boroughs'}}>Borough</a>
-                    {{ember-tooltip delay=500 text='Create selection area using boroughs'}}
-                  </li>
-                  <li class="{{if (eq this.selection.summaryLevel 'boroughs') 'active'}} explode-borough">
-                    <a href="#" data-test-toggle-boroughs {{action this.handleSummaryLevelToggle 'boroughs'}}>Borough</a>
-                    {{ember-tooltip delay=500 text='Create selection area using boroughs'}}
-                  </li>
-                  {{!-- <a href="#">Census Block</a>
-                  <a href="#">Borough</a>
-                  <a href="#">New York City</a> --}}
-                </ul>
+                <div class="dropdown-content">
+                  <a href="#" class="{{if (eq this.selection.summaryLevel 'blocks') 'active'}} explode-block" data-test-toggle-blocks {{action this.handleSummaryLevelToggle 'blocks'}}>Census Block{{ember-tooltip delay=500 text='Create selection area using census blocks'}}</a>
+                  <a href="#" class="{{if (eq this.selection.summaryLevel 'boroughs') 'active'}} explode-borough" data-test-toggle-boroughs {{action this.handleSummaryLevelToggle 'boroughs'}}>Borough{{ember-tooltip delay=500 text='Create selection area using boroughs'}}</a>
+                  <a href="#">New York City</a>
+                </div>
               </div>
             </li>
           </ul>
         </li>
       </ul>
     </div>
-    {{!-- <li class="menu align-right"><a href="#">Right Side Placeholder</a></li> --}}
     <div class="cell small-2 bar-item">
       <div class="menu align-right">
         <ul class="menu orange-bar--selector" id="more-options-button">

--- a/app/templates/components/selection-details-text.hbs
+++ b/app/templates/components/selection-details-text.hbs
@@ -1,7 +1,10 @@
 {{@selectedCount}}
 {{if (eq @selectedType 'tracts') 'Census Tract'~}}
 {{if (eq @selectedType 'blocks') 'Census Block'~}}
+{{if (eq @selectedType 'cdtas') 'Community District Tabulation Area'~}}
+{{if (eq @selectedType 'districts') 'Comunity District'~}}
 {{if (eq @selectedType 'ntas') 'Neighborhood'~}}
+{{if (eq @selectedType 'boroughs') 'Borough'~}}
 {{if (eq @selectedType 'pumas') 'PUMA'~}}
 {{unless (eq @selectedCount 1) 's'}}
 {{if (eq @selectedType 'blocks') '(Tract Id-Block Id)'~}}

--- a/app/templates/components/selection-details-text.hbs
+++ b/app/templates/components/selection-details-text.hbs
@@ -5,6 +5,7 @@
 {{if (eq @selectedType 'districts') 'Comunity District'~}}
 {{if (eq @selectedType 'ntas') 'Neighborhood'~}}
 {{if (eq @selectedType 'boroughs') 'Borough'~}}
+{{if (eq @selectedType 'cities') 'New York City'~}}
 {{if (eq @selectedType 'pumas') 'PUMA'~}}
 {{unless (eq @selectedCount 1) 's'}}
 {{if (eq @selectedType 'blocks') '(Tract Id-Block Id)'~}}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This adds four new summary levels for users to select - CDTA, Community District, Borough, and New York City.
It also updates the search functionality to return results on the correct levels.

#### Tasks/Bug Numbers
 - Completes (with changes to layers api and factfinder api) [AB#3142](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3142) and [AB#3148](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3148)
<!---
Provide a link to a ticket, if applicable
-->


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
