### PR TITLE
4150 Menus on data explorer page now close when clicking outside of menu

### DIFF
--- a/app/components/explorer/download-data-dropdown.js
+++ b/app/components/explorer/download-data-dropdown.js
@@ -9,6 +9,10 @@ export default class DownloadDataDropdown extends Component{
     this.open = !this.open;
   }
 
+  @action closeMenu() {
+    this.open = false;
+  }
+  
   @action downloadCSV(csv) {
     var csvFile;
     var downloadLink;

--- a/app/components/explorer/modify-tables-menu.js
+++ b/app/components/explorer/modify-tables-menu.js
@@ -8,4 +8,8 @@ export default class ModifyTablesMenuComponent extends Component {
   @action toggleOpen() {
     this.open = !this.open;
   }
+
+  @action closeMenu() {
+    this.open = false;
+  }
 }

--- a/app/components/explorer/source-select-dropdown.js
+++ b/app/components/explorer/source-select-dropdown.js
@@ -14,6 +14,10 @@ export default class SourceSelectDropdownComponent extends Component {
     this.open = !this.open;
   }
 
+  @action closeMenu() {
+    this.open = false;
+  }
+
   get source() {
     return this.args.sources.find(source => source.selected);
   }

--- a/app/components/explorer/topic-select-dropdown.js
+++ b/app/components/explorer/topic-select-dropdown.js
@@ -41,4 +41,8 @@ export default class TopicSelectDropdownComponent extends Component {
   @action toggleOpen() {
     this.open = !this.open;
   }
+
+  @action closeMenu() {
+    this.open = false;
+  }
 }

--- a/app/templates/components/explorer/download-data-dropdown.hbs
+++ b/app/templates/components/explorer/download-data-dropdown.hbs
@@ -15,7 +15,10 @@
 </button>
 
 {{#if this.open}}
-  <div class="download-data-dropdown">
+  <div
+   class="download-data-dropdown"
+   {{on-click-outside (action "closeMenu")}}
+  >
     <div class="triangle">
     </div>
     <div class="download-data-dropdown-head">

--- a/app/templates/components/explorer/modify-tables-menu.hbs
+++ b/app/templates/components/explorer/modify-tables-menu.hbs
@@ -1,5 +1,6 @@
 <div
   class="bar-item"
+  {{on-click-outside (action "closeMenu")}}
 >
   <button
     id="modify-tables-button"

--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -1,5 +1,6 @@
 <div
   class="bar-item"
+  {{on-click-outside (action "closeMenu")}}
 >
   <button
     class="source-select-toggle button gray expanded no-margin"

--- a/app/templates/components/explorer/topic-select-dropdown.hbs
+++ b/app/templates/components/explorer/topic-select-dropdown.hbs
@@ -1,5 +1,6 @@
 <div
   class="bar-item"
+  {{on-click-outside (action "closeMenu")}}
 >
   <button
     class="topic-select-toggle button gray expanded no-margin"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-cli-postcss": "^7.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
+    "ember-click-outside": "^2.0.0",
     "ember-composable-helpers": "^4.5.0",
     "ember-concurrency": "^0.8.12",
     "ember-copy": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,7 +6145,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.16.0,
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.4.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.4.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6276,7 +6276,7 @@ ember-cli-htmlbars@^3.0.0:
     json-stable-stringify "^1.0.1"
     strip-bom "^3.0.0"
 
-ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.3.1:
+ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz#d299e4f7eba6f30dc723ee086906cc550beb252e"
   integrity sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==
@@ -6635,6 +6635,15 @@ ember-cli@~3.26.1:
     watch-detector "^1.0.0"
     workerpool "^6.0.3"
     yam "^1.0.0"
+
+ember-click-outside@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-click-outside/-/ember-click-outside-2.0.0.tgz#4b056a1f737ed2b2c933b05fff7b3501c967cd8f"
+  integrity sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==
+  dependencies:
+    ember-cli-babel "^7.18.0"
+    ember-cli-htmlbars "^4.2.3"
+    ember-modifier "^2.1.0"
 
 ember-compatibility-helpers@1.2.1, ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Now, when clicking outside of an open menu on the data explorer page, the menu will automatically close.  Commit message is incorrect, it is the data explorer page, not the custom map study page. 

#### Tasks/Bug Numbers
 - Fixes [AB#4150](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4150)


### Technical Explanation
Uses an ember addon called ember-click-outside.  Documentation: https://github.com/zeppelin/ember-click-outside

### Any other info you think would help a reviewer understand this PR?
