### PR TITLE
4103 Pass selected geo to Explorer

### DIFF
--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -10,6 +10,29 @@ import choroplethConfigs from '../choropleth-config';
 
 const { SupportServiceHost } = Environment;
 
+// This is the compliment of the `getGeotypeFromIdPrefix`
+// function in the Factfinder API repo (utils/geotype-from-id-prefix.js)
+function getIdPrefixFromGeotype(idPrefix) {
+  switch (idPrefix) {
+    case 'selection':
+        return 'SID';
+    case 'ntas':
+        return'NTA' ;
+    case 'tracts':
+        return 'TRACT';
+    case 'cdtas':
+        return 'CDTA';
+    case 'districts':
+        return 'DIST';
+    case 'blocks':
+        return 'BLOCK';
+    case 'boroughs':
+        return 'BORO';
+    default:
+      return null;
+  }
+}
+
 export default Component.extend({
   selection: service(),
   router: service(),
@@ -132,7 +155,20 @@ export default Component.extend({
     const geoids = this.get('selection.current.features')
       .mapBy('properties.geoid');
 
-    this.get('generateProfileTask').perform(type, geoids);
+    if (geoids.length > 1) {
+      this.get('generateProfileTask').perform(type, geoids);
+    } else if (geoids.length === 1){
+
+      const factfinderId = `${getIdPrefixFromGeotype(type)}_${geoids[0]}`;
+
+      this.get('router').transitionTo('explorer', factfinderId, {
+        queryParams: {
+          mode: 'current', comparator: 'BORO_NYC', reliability: false, charts: true,
+        },
+      });
+    } else {
+      console.log("Warning: Cannot generate profile because selected geoids array is empty.")
+    }
   },
 
   setChoroplethMode(mode) {

--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -87,7 +87,7 @@ export default Component.extend({
 
   generateProfileTask: task(function* (type, geoids) {
     const postBody = {
-      type,
+      _type: type,
       geoids,
     };
 
@@ -101,7 +101,7 @@ export default Component.extend({
       .then(d => d.json());
 
     yield this.get('router')
-      .transitionTo('explorer', {
+      .transitionTo('explorer', id, {
         queryParams: {
           mode: 'current', comparator: '0', reliability: false, charts: true,
         },

--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -124,11 +124,7 @@ export default Component.extend({
       .then(d => d.json());
 
     yield this.get('router')
-      .transitionTo('explorer', id, {
-        queryParams: {
-          mode: 'current', comparator: '0', reliability: false, charts: true,
-        },
-      });
+      .transitionTo('explorer', id);
   }).restartable(),
 
   clearSelection() {
@@ -161,11 +157,7 @@ export default Component.extend({
 
       const factfinderId = `${getIdPrefixFromGeotype(type)}_${geoids[0]}`;
 
-      this.get('router').transitionTo('explorer', factfinderId, {
-        queryParams: {
-          mode: 'current', comparator: 'BORO_NYC', reliability: false, charts: true,
-        },
-      });
+      this.get('router').transitionTo('explorer', factfinderId);
     } else {
       console.log("Warning: Cannot generate profile because selected geoids array is empty.")
     }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -47,7 +47,7 @@ export default Route.extend({
 
         // Census selection groups
         { id: 'factfinder--census-blocks', visible: false },
-        { id: 'factfinder--census-tracts', visible: false },
+        { id: 'factfinder--census-tracts-2020', visible: false },
         { id: 'factfinder--cdtas', visible: false },
         { id: 'factfinder--districts', visible: false },
         { id: 'factfinder--boroughs', visible: false },

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -102,7 +102,7 @@ export default Service.extend({
     const layerGroupIdMap = (level) => {
       switch (level) {
         case 'tracts':
-          return 'factfinder--census-tracts';
+          return 'factfinder--census-tracts-2020';
         case 'blocks':
           return 'factfinder--census-blocks';
         case 'cdtas':


### PR DESCRIPTION
### Summary
This PR
  1.  tweaks the signature of the POST request to the selection POST endpoint. Necessary to integrate with changes in https://github.com/NYCPlanning/labs-factfinder-api/pull/124
  2. Determines if the user selected one or multiple geographies. If...
    a. Multiple geographies selected:  Acquires selecttion id from the selection POST endpoint. Then passes the newly acquired selection ID (hash from the Selection table) to the Explorer route.
    b. Single geography selected: Passes the single geoid directly to the Explorer route 
  3. Makes sure the NTA geography layer is pointing to the `factfinder--census-tracts-2020` Layers API layer instead of ``factfinder--census-tracts`. The former contains the actual new, ad hoc 2020 geography. 

#### Tasks/Bug Numbers
Fixes [AB#4103](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4103) 
