### PR TITLE
4608 Use official geographies from BYTES

### DIFF
--- a/app/queries/summary-levels.js
+++ b/app/queries/summary-levels.js
@@ -9,7 +9,7 @@ export default {
       bctcb2020,
       geoid AS geoid,
       bctcb2020 as geolabel
-    FROM nycb2020_fixed
+    FROM pff_2020_census_blocks_21c
   `,
 
   tracts: (webmercator = true) => `
@@ -20,7 +20,7 @@ export default {
       boroct2020,
       nta2020,
       boroct2020 AS geoid
-    FROM nyct2020
+    FROM pff_2020_census_tracts_21c
   `,
 
   cdtas: (webmercator = true) => `
@@ -32,7 +32,7 @@ export default {
       boroname,
       borocode::text,
       cdta2020 AS geoid
-    FROM nycdta2020
+    FROM pff_2020_cdtas_21c
   `,
 
   districts: (webmercator = true) => `
@@ -40,7 +40,7 @@ export default {
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
       borocd as geolabel,
       borocd AS geoid
-    FROM nycd2020
+    FROM pff_2020_community_districts_21c
   `,
 
   boroughs: (webmercator = true) => `
@@ -48,7 +48,7 @@ export default {
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
       boroname as geolabel,
       borocode AS geoid
-    FROM nybb2020
+    FROM pff_2020_boroughs_21c
   `,
 
   cities: (webmercator = true) => `
@@ -56,7 +56,7 @@ export default {
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
       city as geolabel,
       city AS geoid
-    FROM nycity2020
+    FROM pff_2020_city_21c
   `,
 
   ntas: (webmercator = true) => `
@@ -66,7 +66,7 @@ export default {
       nta2020,
       nta2020 as geolabel,
       nta2020 AS geoid
-    FROM nynta2020
+    FROM pff_2020_ntas_21c
     WHERE ntaname NOT ILIKE 'park-cemetery-etc%25'
       AND ntaname != 'Airport'
   `,

--- a/app/sources/census-admin-boundaries.js
+++ b/app/sources/census-admin-boundaries.js
@@ -6,7 +6,7 @@ export default {
       id: 'neighborhood-tabulation-areas',
       sql: `
         SELECT a.the_geom_webmercator, ntaname, nta2020, nta2020 AS geolabel, a.nta2020 AS geoid
-        FROM nynta2020 a
+        FROM pff_2020_ntas_21c a
         WHERE ntaname NOT ILIKE 'park-cemetery-etc%'
           AND ntaname != 'Airport'
       `,
@@ -14,37 +14,37 @@ export default {
 
     {
       id: 'neighborhood-tabulation-areas-centroids',
-      sql: 'SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM nynta2020 WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
+      sql: 'SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM pff_2020_ntas_21c WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
     },
 
     {
       id: 'cdtas',
-      sql: 'SELECT the_geom_webmercator, cdtaname AS geolabel, cdta2020 AS geoid FROM nycdta2020',
+      sql: 'SELECT the_geom_webmercator, cdtaname AS geolabel, cdta2020 AS geoid FROM pff_2020_cdtas_21c',
     },
 
     {
       id: 'tracts',
-      sql: 'SELECT the_geom_webmercator, ctlabel as geolabel, boroct2020 AS geoid FROM nyct2020',
+      sql: 'SELECT the_geom_webmercator, ctlabel as geolabel, boroct2020 AS geoid FROM pff_2020_census_tracts_21c',
     },
 
     {
       id: 'blocks',
-      sql: 'SELECT the_geom_webmercator, bctcb2020 as geolabel, geoid AS geoid FROM nycb2020_fixed',
+      sql: 'SELECT the_geom_webmercator, bctcb2020 as geolabel, geoid AS geoid FROM pff_2020_census_blocks_21c',
     },
 
     {
       id: 'districts',
-      sql: 'SELECT the_geom_webmercator, borocd AS geolabel, borocd AS geoid FROM nycd2020',
+      sql: 'SELECT the_geom_webmercator, borocd AS geolabel, borocd AS geoid FROM pff_2020_community_districts_21c',
     },
 
     {
       id: 'boroughs',
-      sql: 'SELECT the_geom_webmercator, boroname AS geolabel, borocode AS geoid FROM nybb2020',
+      sql: 'SELECT the_geom_webmercator, boroname AS geolabel, borocode AS geoid FROM pff_2020_boroughs_21c',
     },
 
     {
       id: 'cities',
-      sql: 'SELECT the_geom_webmercator, city AS geolabel, city AS geoid FROM nycity2020',
+      sql: 'SELECT the_geom_webmercator, city AS geolabel, city AS geoid FROM pff_2020_city_21c',
     },
 
     {


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This update replaces the CARTO tables temporarily being used with the finalized version of the data from BYTES.

#### Tasks/Bug Numbers
 - Closes [AB#4608](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4608)


### Technical Explanation
The updated table names are as follows:
Geo | Old Name | New Name
Census Tract | nyct2020 | pff_2020_census_tracts_21c
NTA | nynta2020 | pff_2020_ntas_21c
CDTA | nycdta2020 | pff_2020_cdtas_21c
District | nycd2020 | pff_2020_community_districts_21c
Census Block | nycb2020_fixed | pff_2020_census_blocks_21c
Borough | nybb2020 | pff_2020_boroughs_21c
City | nycity2020 | pff_2020_city_21c



### Any other info you think would help a reviewer understand this PR?
