### PR TITLE
4221 - MOE - Greyed out data deemed insignificant

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -571,7 +571,7 @@ tr {
   }
 }
 
-.shows-signficance .insignificant { color: $silver; }
+.insignificant { color: $silver; }
 
 .no-compare-message {
   overflow: visible;


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->
Unreliable data now appears as grey instead of black

#### Tasks/Bug Numbers
 - Closes [AB#4221](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4221)


### Technical Explanation
Quick CSS fix.  The "shows-significance" class is no longer being used.  The "insignificant" class is not being used anywhere but the unreliable data, so we could safely remove the "shows-significance" portion of the style.

### Any other info you think would help a reviewer understand this PR?
