### PR TITLE
4652 - Returning to Custom Map Study from Explorer alters selected geometry

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -48,7 +48,6 @@ export default Route.extend({
         // Census selection groups
         { id: 'factfinder--census-blocks', visible: false },
         { id: 'factfinder--census-tracts-2020', visible: false },
-        { id: 'factfinder--cdtas', visible: false },
         { id: 'factfinder--districts', visible: false },
         { id: 'factfinder--boroughs', visible: false },
         { id: 'factfinder--cities', visible: false },

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -97,6 +97,9 @@ export default Service.extend({
   // methods
   handleSummaryLevelToggle(toLevel) {
     const fromLevel = this.get('summaryLevel');
+    if(fromLevel === toLevel) {
+      return;
+    }
     this.set('summaryLevel', toLevel);
 
     const layerGroupIdMap = (level) => {


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This fixes the issue of the selected area expanding when returning to the map page from the data explorer.  It also fixes the console errors on the custom map study page.

#### Tasks/Bug Numbers
 - Fixes [AB#4652](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4652)

### Technical Explanation
The console errors were due to the removed row being a duplicate (it still exists in row 56).
The geometries were altered because handleSummaryLevelToggle fires when the map page loads, which when a summary level was already selected, was expanding the area.  The fix simply exits the function without doing anything if it is triggered to toggle to the same level it already was.

### Any other info you think would help a reviewer understand this PR?
