### PR TITLE
4281 Dynamic segments for geotype and geoid

### DIFF
--- a/app/adapters/row.js
+++ b/app/adapters/row.js
@@ -7,8 +7,9 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { selectionId, compareTo = 0 } = query;
-    const URL = `${SupportServiceHost}/profile/${selectionId}?compareTo=${compareTo}`;
+    const { geotype = 'boroughs', geoid = 'NYC', compareTo = 0 } = query;
+
+    const URL = `${SupportServiceHost}/profile/${geotype}/${geoid}?compareTo=${compareTo}`;
 
     return fetch(URL)
       .then(d => d.json());

--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -10,29 +10,6 @@ import choroplethConfigs from '../choropleth-config';
 
 const { SupportServiceHost } = Environment;
 
-// This is the compliment of the `getGeotypeFromIdPrefix`
-// function in the Factfinder API repo (utils/geotype-from-id-prefix.js)
-function getIdPrefixFromGeotype(idPrefix) {
-  switch (idPrefix) {
-    case 'selection':
-        return 'SID';
-    case 'ntas':
-        return'NTA' ;
-    case 'tracts':
-        return 'TRACT';
-    case 'cdtas':
-        return 'CDTA';
-    case 'districts':
-        return 'DIST';
-    case 'blocks':
-        return 'BLOCK';
-    case 'boroughs':
-        return 'BORO';
-    default:
-      return null;
-  }
-}
-
 export default Component.extend({
   selection: service(),
   router: service(),
@@ -108,7 +85,7 @@ export default Component.extend({
       geoids,
     };
 
-    const { id } = yield fetch(`${SupportServiceHost}/selection`, { // eslint-disable-line
+    const { id: selectionId } = yield fetch(`${SupportServiceHost}/selection`, { // eslint-disable-line
       headers: {
         'Content-Type': 'application/json',
       },
@@ -118,7 +95,7 @@ export default Component.extend({
       .then(d => d.json());
 
     yield this.get('router')
-      .transitionTo('explorer', id);
+      .transitionTo(`/explorer/selection/${selectionId}`);
   }).restartable(),
 
   clearSelection() {
@@ -148,10 +125,10 @@ export default Component.extend({
     if (geoids.length > 1) {
       this.get('generateExplorerPageTask').perform(type, geoids);
     } else if (geoids.length === 1){
-
-      const factfinderId = `${getIdPrefixFromGeotype(type)}_${geoids[0]}`;
-
-      this.get('router').transitionTo('explorer', factfinderId);
+      this.get('router').transitionTo('explorer', {
+        geotype: type,
+        geoid: geoids[0]
+      });
     } else {
       console.log("Warning: Cannot generate profile because selected geoids array is empty.")
     }

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -119,7 +119,7 @@ export default class ExplorerController extends Controller {
   set source(newSource) {
     const { id } = newSource;
 
-    this.transitionToRoute('explorer', this.model.selectionOrGeoid, { queryParams: { source: id }});
+    this.transitionToRoute('explorer', { queryParams: { source: id }});
   }
 
   // returns either 'current', 'previous' or 'change'
@@ -164,7 +164,7 @@ export default class ExplorerController extends Controller {
   set topics(newTopics) {
     const qpKey = this.source.type === 'census' ? 'censusTopics' : 'acsTopics';
 
-    this.transitionToRoute('explorer', this.model.selectionOrGeoid, { queryParams: { [qpKey]: newTopics }});
+    this.transitionToRoute('explorer', { queryParams: { [qpKey]: newTopics }});
   }
 
   get isAllTopicsSelected() {
@@ -250,7 +250,7 @@ export default class ExplorerController extends Controller {
   @action toggleBooleanControl(controlId) {
     let { [controlId]: currentControlValue } = this;
 
-    this.transitionToRoute('explorer', this.model.selectionOrGeoid, { queryParams: {
+    this.transitionToRoute('explorer', { queryParams: {
       [controlId]: !currentControlValue,
     }});
   }
@@ -258,11 +258,11 @@ export default class ExplorerController extends Controller {
   @task({ restartable: true }) *reloadExplorerModel(newGeoid) {
     yield this.store.unloadAll('row');
 
-    const newExplorerModel = yield fetchExplorerModel(this.store, this.model.selectionOrGeoid, newGeoid);
+    const newExplorerModel = yield fetchExplorerModel(this.store, this.model.selection.type, this.model.selectionOrGeoid, newGeoid);
 
     this.model = newExplorerModel;
 
-    yield this.transitionToRoute('explorer', this.model.selectionOrGeoid, { queryParams: { compareTo: newGeoid }});
+    yield this.transitionToRoute('explorer', { queryParams: { compareTo: newGeoid }});
   }
 
   @action updateCompareTo(geoid) {

--- a/app/router.js
+++ b/app/router.js
@@ -8,7 +8,7 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () { // eslint-disable-line
-  this.route('explorer', { path: 'explorer/:id' });
+  this.route('explorer', { path: 'explorer/:geotype/:geoid' });
   this.route('about');
   this.route('features');
   this.route('data');

--- a/app/routes/explorer.js
+++ b/app/routes/explorer.js
@@ -1,40 +1,21 @@
 import Route from '@ember/routing/route';
-
-import Environment from '../config/environment';
-import nestProfile from '../utils/nest-profile';
-
-const { SupportServiceHost } = Environment;
-
-const SELECTION_API_URL = id => `${SupportServiceHost}/selection/${id}`;
-
-const COMPARISON_GEO_OPTIONS_URL = `${SupportServiceHost}/geo-options`;
+import fetchExplorerModel from '../utils/fetch-explorer-model';
 
 export default class ExplorerRoute extends Route {
   beforeModel() {
     this.store.unloadAll('row');
   }
 
-  async model({ id, compareTo }) { // eslint-disable-line
-    let selectionResponse = null;
-    let profileResponse = null;
-    let selectionId = id || "0"; // "0" maps to 'nyc'
+  async model({ compareTo }, {
+    to: {
+      params: {
+        geotype,
+        geoid
+      }
+    }
+  }) { // eslint-disable-line
+    const newModel = await fetchExplorerModel(this.store, geotype, geoid, compareTo);
 
-    selectionResponse = await fetch(SELECTION_API_URL(id));
-    selectionResponse = await selectionResponse.json();
-
-    profileResponse = await this.store.query('row', { selectionId, compareTo});
-    profileResponse = profileResponse.toArray();
-
-    const nestedProfileModel = nestProfile(profileResponse, 'variable');
-
-    let comparisonGeoOptions = await fetch(COMPARISON_GEO_OPTIONS_URL);
-    comparisonGeoOptions = await comparisonGeoOptions.json();
-
-    return {
-      selectionOrGeoid: id,
-      selection: selectionResponse,
-      profile: nestedProfileModel,
-      comparisonGeoOptions
-    };
+    return newModel;
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,15 +14,15 @@
       {{/link-to}}
     </li>
     <li>
-      <LinkTo
-        @route='explorer'
-        @model='nyc'
-        class={{(if (eq this.router.currentRouteName "explorer") "active-route")}}
-      >
-        {{fa-icon icon="search" prefix="fa" transform='grow-4'}}
-        Data Explorer
-      </LinkTo>
-    </li>
+    <LinkTo
+      @route='explorer'
+      @model={{array 'boroughs' 'nyc'}}
+      class={{(if (eq this.router.currentRouteName "explorer") "active-route")}}
+    >
+      {{fa-icon icon="search" prefix="fa" transform='grow-4'}}
+      Data Explorer
+    </LinkTo>
+  </li>
   </ul>
 </banner.nav>
 </LabsUi::SiteHeader>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,14 +14,12 @@
       {{/link-to}}
     </li>
     <li>
-    <LinkTo
-      @route='explorer'
-      @model={{array 'boroughs' 'nyc'}}
+    <a href="explorer/boroughs/NYC"
       class={{(if (eq this.router.currentRouteName "explorer") "active-route")}}
     >
       {{fa-icon icon="search" prefix="fa" transform='grow-4'}}
       Data Explorer
-    </LinkTo>
+    </a>
   </li>
   </ul>
 </banner.nav>

--- a/app/utils/fetch-explorer-model.js
+++ b/app/utils/fetch-explorer-model.js
@@ -3,19 +3,18 @@ import nestProfile from '../utils/nest-profile';
 
 const { SupportServiceHost } = Environment;
 
-const SELECTION_API_URL = id => `${SupportServiceHost}/selection/${id}`;
+const SELECTION_API_URL = (geotype = 'boroughs', geoid = 'NYC') => `${SupportServiceHost}/selection/${geotype}/${geoid}`;
 
 const COMPARISON_GEO_OPTIONS_URL = `${SupportServiceHost}/geo-options`;
 
-export default async function fetchExplorerModel(store, id, compareTo) {
+export default async function fetchExplorerModel(store, geotype, geoid, compareTo) {
   let selectionResponse = null;
   let profileResponse = null;
-  let selectionId = id || "0"; // "0" maps to 'nyc'
 
-  selectionResponse = await fetch(SELECTION_API_URL(id));
+  selectionResponse = await fetch(SELECTION_API_URL(geotype, geoid));
   selectionResponse = await selectionResponse.json();
 
-  profileResponse = await store.query('row', { selectionId, compareTo});
+  profileResponse = await store.query('row', {geotype, geoid, compareTo});
   profileResponse = profileResponse.toArray();
 
   const nestedProfileModel = nestProfile(profileResponse, 'variable');
@@ -24,7 +23,7 @@ export default async function fetchExplorerModel(store, id, compareTo) {
   comparisonGeoOptions = await comparisonGeoOptions.json();
 
   return {
-    selectionOrGeoid: id,
+    selectionOrGeoid: geoid,
     selection: selectionResponse,
     profile: nestedProfileModel,
     comparisonGeoOptions


### PR DESCRIPTION
### Summary
API was recently changed so that  Selection and Profile endpoints to have :geotype and :geoid dynamic segments, replacing the previous Factfinder ID. See updated README in Factfinder API for new API.

This PR updates fetch requests on the frontend to integrate with the new API. 

Pairs with https://github.com/NYCPlanning/labs-factfinder-api/pull/131

Depends on/merge after https://github.com/NYCPlanning/labs-factfinder-api/pull/130

#### Tasks/Bug Numbers
 - Fixes [AB#4281](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4281)

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
