### PR TITLE
4652 - Geo Selection Toggle (FIX)

### DIFF
--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -129,10 +129,6 @@ export default Service.extend({
     fromLayerGroup.set('visible', false);
     toLayerGroup.set('visible', true);
 
-    if(fromLevel === toLevel) {
-      return;
-    }
-
     // remove mapbox neighborhood labels if current Level is NTAs
     const map = this.get('currentMapInstance');
     if (map) {
@@ -154,6 +150,10 @@ export default Service.extend({
 
   // transition between geometry levels using spatial queries
   explodeGeo(fromLevel, toLevel) {
+    if(fromLevel === toLevel) {
+      return;
+    }
+
     const crossWalkFromTable = SUM_LEVEL_DICT[fromLevel].sql;
     const crossWalkToTable = SUM_LEVEL_DICT[toLevel].sql;
 

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -97,9 +97,7 @@ export default Service.extend({
   // methods
   handleSummaryLevelToggle(toLevel) {
     const fromLevel = this.get('summaryLevel');
-    if(fromLevel === toLevel) {
-      return;
-    }
+
     this.set('summaryLevel', toLevel);
 
     const layerGroupIdMap = (level) => {
@@ -130,6 +128,10 @@ export default Service.extend({
 
     fromLayerGroup.set('visible', false);
     toLayerGroup.set('visible', true);
+
+    if(fromLevel === toLevel) {
+      return;
+    }
 
     // remove mapbox neighborhood labels if current Level is NTAs
     const map = this.get('currentMapInstance');


### PR DESCRIPTION
### Summary
Initial fix was preventing the Census Tracts from appearing when first loading the site.  This fix moves the check to prevent toggling to the same level until later in the function, so that the layer group will render on initial page load.

#### Tasks/Bug Numbers
 - Fixes [AB#4652](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4652)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
