### PR TITLE
4843  Accept `cities` geotype and various NYC geoids

### DIFF
--- a/app/adapters/acs-row.js
+++ b/app/adapters/acs-row.js
@@ -7,7 +7,7 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { geotype = 'cities', geoid = 'NYC', compareTo = 0 } = query;
+    const { geotype = 'cities', geoid = 'NYC', compareTo = 1 } = query;
 
     const URL = `${SupportServiceHost}/survey/acs/${geotype}/${geoid}?compareTo=${compareTo}`;
 

--- a/app/adapters/acs-row.js
+++ b/app/adapters/acs-row.js
@@ -7,7 +7,7 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { geotype = 'boroughs', geoid = 'NYC', compareTo = 0 } = query;
+    const { geotype = 'cities', geoid = 'NYC', compareTo = 0 } = query;
 
     const URL = `${SupportServiceHost}/survey/acs/${geotype}/${geoid}?compareTo=${compareTo}`;
 

--- a/app/adapters/decennial-row.js
+++ b/app/adapters/decennial-row.js
@@ -7,7 +7,7 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { geotype = 'cities', geoid = 'NYC', compareTo = 0 } = query;
+    const { geotype = 'cities', geoid = 'NYC', compareTo = 1 } = query;
 
     const URL = `${SupportServiceHost}/survey/decennial/${geotype}/${geoid}?compareTo=${compareTo}`;
 

--- a/app/adapters/decennial-row.js
+++ b/app/adapters/decennial-row.js
@@ -7,7 +7,7 @@ const { SupportServiceHost } = Environment;
 
 export default DS.JSONAPIAdapter.extend({
   query(store, modelType, query) {
-    const { geotype = 'boroughs', geoid = 'NYC', compareTo = 0 } = query;
+    const { geotype = 'cities', geoid = 'NYC', compareTo = 0 } = query;
 
     const URL = `${SupportServiceHost}/survey/decennial/${geotype}/${geoid}?compareTo=${compareTo}`;
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,7 +14,7 @@
       {{/link-to}}
     </li>
     <li>
-    <a href="explorer/cities/NYC"
+    <a href="explorer/cities/NYC?compareTo=1"
       class={{(if (eq this.router.currentRouteName "explorer") "active-route")}}
     >
       {{fa-icon icon="search" prefix="fa" transform='grow-4'}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,7 +14,7 @@
       {{/link-to}}
     </li>
     <li>
-    <a href="explorer/boroughs/NYC"
+    <a href="explorer/cities/NYC"
       class={{(if (eq this.router.currentRouteName "explorer") "active-route")}}
     >
       {{fa-icon icon="search" prefix="fa" transform='grow-4'}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,7 +14,7 @@
       {{/link-to}}
     </li>
     <li>
-    <a href="explorer/cities/NYC?compareTo=1"
+    <a href="/explorer/cities/NYC?compareTo=1"
       class={{(if (eq this.router.currentRouteName "explorer") "active-route")}}
     >
       {{fa-icon icon="search" prefix="fa" transform='grow-4'}}

--- a/app/utils/fetch-explorer-model.js
+++ b/app/utils/fetch-explorer-model.js
@@ -4,7 +4,7 @@ import nestSurvey from './nest-survey';
 const { SupportServiceHost } = Environment;
 
 // TODO: Rename endpoint to geography
-const SELECTION_API_URL = (geotype = 'boroughs', geoid = 'NYC') => `${SupportServiceHost}/selection/${geotype}/${geoid}`;
+const SELECTION_API_URL = (geotype = 'cities', geoid = 'NYC') => `${SupportServiceHost}/selection/${geotype}/${geoid}`;
 
 const COMPARISON_GEO_OPTIONS_URL = `${SupportServiceHost}/geo-options`;
 

--- a/app/utils/fetch-explorer-model.js
+++ b/app/utils/fetch-explorer-model.js
@@ -9,7 +9,7 @@ const SELECTION_API_URL = (geotype = 'cities', geoid = 'NYC') => `${SupportServi
 const COMPARISON_GEO_OPTIONS_URL = `${SupportServiceHost}/geo-options`;
 
 
-export default async function fetchExplorerModel(store, geotype, geoid, compareTo = '0') {
+export default async function fetchExplorerModel(store, geotype, geoid, compareTo = '1') {
   let selectionResponse = null;
   let acsSurveyResponse = null;
   let decennialSurveyResponse = null;


### PR DESCRIPTION
### Summary
Previously the Explorer URLs to access citywide/NYC data involved `boroughs` as the geotype and `NYC` as the geoid. 
This PR changes the endpoints so that NYC geoid(s) pair with the `cities` geotype, as it should.

E.g. old Explorer URL:
`/explorer/boroughs/NYC`

New:
`/explorer/cities/NYC`

Also the explorer URL now accepts different forms of the NYC geoid, e.g. 'New York City'.

This is also necessary because the Carto layer for NYC uses the geoid 'New York City'.

Additionally, geoids are now case-insensitive.

Pairs with https://github.com/NYCPlanning/labs-factfinder-api/pull/135

#### Tasks/Bug Numbers
 - Fixes [AB#4843](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4843)
