### PR TITLE
Environment variables for using local APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You will need the following things properly installed on your computer.
 - Clone this repo `https://github.com/NYCPlanning/labs-nyc-factfinder.git`
 - Install Dependencies `yarn`
 - Start the server `yarn run start`
+  - If running labs-factfinder-api and labs-layers-api locally, instead start the server with `yarn run local-api`
 
 ### Development shortcut
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -100,6 +100,15 @@ module.exports = function (environment) {
     features: [],
   };
 
+if (environment === 'local-api') {
+  ENV.SupportServiceHost = 'http://localhost:3000';
+  ENV['mapbox-gl'].map.style = 'http://localhost:3120/v1/base/style.json';
+  ENV['ember-mapbox-composer'].host = 'http://localhost:3120';
+  ENV['ember-cli-mirage'] = {
+    enabled: false,
+  };
+}
+
   if (environment === 'development') {
     // ENV.DEFAULT_SELECTION = SAMPLE_SELECTION;
     ENV.SupportServiceHost = 'https://factfinder-api-develop.herokuapp.com';

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
     "screenshot": "touch config/environment.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "local-api": "ember serve --environment=local-api"
   },
   "devDependencies": {
     "@csstools/postcss-sass": "^4.0.0",


### PR DESCRIPTION
### Summary
You can use 'yarn run local-api' to start a development server which uses labs-factfinder-api and labs-layers-api also running on localhost.
