### PR TITLE
4112 Key interface elements are inaccessible within Topics dropdown

### DIFF
--- a/app/styles/modules/components/explorer/topic-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/topic-select-dropdown.scss
@@ -27,6 +27,8 @@
   border-radius: 5px;
   text-align: left !important;
   z-index: 100;
+  max-height: calc(100vh - 29.5rem);
+  overflow: auto;
 
   .clickable {
     cursor: pointer;


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Users could open multiple tabs in the dropdown, making it larger than the screen height and rendering them unable to view portions of the menu.  The menu now has a maximum height, after which a scrollbar will appear.

#### Tasks/Bug Numbers
 - Fixes [AB#4112](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4112)

### Technical Explanation
It's 2 lines of CSS copied from the download-data-dropdown-body class.

### Any other info you think would help a reviewer understand this PR?
