### PR TITLE
4112 Key interface elements are inaccessible within Topics dropdown (FIX)

### DIFF
--- a/app/styles/modules/components/explorer/topic-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/topic-select-dropdown.scss
@@ -27,7 +27,7 @@
   border-radius: 5px;
   text-align: left !important;
   z-index: 100;
-  max-height: calc(100vh - 29.5rem);
+  max-height: calc(100vh - 15rem);
   overflow: auto;
 
   .clickable {


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Updated drop-down height to account for small window sizes.

#### Tasks/Bug Numbers
 - Fixes [AB#4112](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4112)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
