### PR TITLE
4182 On Explorer, disable ACS source for community districts and blocks

### DIFF
--- a/app/components/explorer/source-select-dropdown.js
+++ b/app/components/explorer/source-select-dropdown.js
@@ -29,4 +29,11 @@ export default class SourceSelectDropdownComponent extends Component {
   get acsSources() {
     return this.args.sources.filter(source => source.type === 'acs');
   }
+
+  get showACS() {
+    if(['districts', 'blocks'].includes(this.args.geoType)) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/app/components/explorer/source-select-dropdown.js
+++ b/app/components/explorer/source-select-dropdown.js
@@ -31,7 +31,7 @@ export default class SourceSelectDropdownComponent extends Component {
   }
 
   get showACS() {
-    if(['districts', 'blocks'].includes(this.args.geoType)) {
+    if(['districts', 'blocks'].includes(this.args.geotype)) {
       return false;
     }
     return true;

--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -49,27 +49,29 @@
           </div>
         {{/each}}
 
-        American Community Survey (ACS)
-        {{#each this.acsSources key="id" as |source|}}
-          <div
-            class="nestable-list-item grid-x clickable"
-            {{on "click" (fn @setSource source)}}
-          >
-            <div class="cell small-1">
-              <span class="a11y-orange">
-                {{#if source.selected}}
-                  {{fa-icon icon='dot-circle' prefix='far'}}
-                {{else}}
-                  {{fa-icon icon='circle' prefix='far' class='silver'}}
-                {{/if}}
-              </span>
-            </div>
+        {{#if this.showACS}}
+          American Community Survey (ACS)
+          {{#each this.acsSources key="id" as |source|}}
+            <div
+              class="nestable-list-item grid-x clickable"
+              {{on "click" (fn @setSource source)}}
+            >
+              <div class="cell small-1">
+                <span class="a11y-orange">
+                  {{#if source.selected}}
+                    {{fa-icon icon='dot-circle' prefix='far'}}
+                  {{else}}
+                    {{fa-icon icon='circle' prefix='far' class='silver'}}
+                  {{/if}}
+                </span>
+              </div>
 
-            <div class="cell auto">
-              {{source.label}}
+              <div class="cell auto">
+                {{source.label}}
+              </div>
             </div>
-          </div>
-        {{/each}}
+          {{/each}}
+        {{/if}}
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -8,7 +8,7 @@
         @sources={{@sources}}
         @setSource={{@setSource}}
         @isModelLoading={{@isModelLoading}}
-        @geoType={{@geoType}}
+        @geotype={{@geotype}}
       />
 
       <Explorer::TopicSelectDropdown

--- a/app/templates/components/orange-bar-data-explorer.hbs
+++ b/app/templates/components/orange-bar-data-explorer.hbs
@@ -8,6 +8,7 @@
         @sources={{@sources}}
         @setSource={{@setSource}}
         @isModelLoading={{@isModelLoading}}
+        @geoType={{@geoType}}
       />
 
       <Explorer::TopicSelectDropdown

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -13,7 +13,7 @@
     @toggleBooleanControl={{this.toggleBooleanControl}}
     @updateCompareTo={{this.updateCompareTo}}
     @isModelLoading={{this.reloadExplorerModel.isRunning}}
-    @geoType={{this.model.selection.type}}
+    @geotype={{this.model.selection.type}}
   />
 </OrangeBar>
 

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -13,6 +13,7 @@
     @toggleBooleanControl={{this.toggleBooleanControl}}
     @updateCompareTo={{this.updateCompareTo}}
     @isModelLoading={{this.reloadExplorerModel.isRunning}}
+    @geoType={{this.model.selection.type}}
   />
 </OrangeBar>
 


### PR DESCRIPTION
### Summary
Updated sources drop-down to hide ACS options if the geotype is districts or blocks.


#### Tasks/Bug Numbers
 - Completes [AB#4182](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4182)


### Technical Explanation
This pulls the geoType from this.model.selection.type (which always shows the geoType) rather than this.model.geotype (which returns 'selection' if more than one geo is selected).

### Any other info you think would help a reviewer understand this PR?
