### PR TITLE
5035 Last row of data is cut off at end of page

### DIFF
--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -158,4 +158,7 @@
       {{/each}}
     {{/if}}
   </div>
+  <div>
+    <hr>
+  </div>
 </div>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
At some screen sizes, there were instances where the last row of data on the page was hidden.  I added an <hr> tag to the end of the page to ensure everything shows.

#### Tasks/Bug Numbers
 - Fixes [AB#5035](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5035)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
