### PR TITLE
Fixing reliability display bug

### DIFF
--- a/app/models/acs-row.js
+++ b/app/models/acs-row.js
@@ -319,10 +319,10 @@ export default DS.Model.extend({
 
   /**
    * !!! WARNING !!!
-   * "significant" actually reflects reliability (calculations were changed in
+   * "differenceSignificant" actually reflects reliability (calculations were changed in
    * the API but variable names have not been updated, check issue #57)
    */
-  significant: DS.attr('boolean'),
+  differenceSignificant: DS.attr('boolean'),
 
   /**
    * See "percent"
@@ -333,14 +333,13 @@ export default DS.Model.extend({
    * See "percentMarginOfError"
    */
   differencePercentMarginOfError: DS.attr('number'),
-  // "percentSignificant" belongs to "difference"
 
   /**
    * !!! WARNING !!!
-   * percentSignificant reflects reliability (calculations were changed in the
+   * differencePercentSignificant reflects reliability (calculations were changed in the
    * API but variable names have not been updated, check issue #57)
    */
-  percentSignificant: DS.attr('boolean'),
+  differencePercentSignificant: DS.attr('boolean'),
   /* =====  End of DIFFERENCE_  ====== */
 
 
@@ -389,7 +388,7 @@ export default DS.Model.extend({
     function() {
       const {
         sum,
-        marginOfError: moe,
+        marginOfError,
         correlationCoefficient,
         percent,
         percentMarginOfError,
@@ -406,7 +405,7 @@ export default DS.Model.extend({
       );
 
       return {
-        sum, moe, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
+        sum, marginOfError, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
       };
     },
   ),
@@ -476,17 +475,17 @@ export default DS.Model.extend({
       const {
         previousSum: sum,
         previousCodingThreshold: direction, // TODO: fix naming
-        previousMarginOfError: moe,
+        previousMarginOfError: marginOfError,
         previousCorrelationCoefficient: correlationCoefficient,
         previousPercent: percent,
         previousPercentMarginOfError: percentMarginOfError,
         previousIsReliable: isReliable,
         previousDifferenceSum: differenceSum,
         previousDifferenceMarginOfError: differenceMarginOfError,
-        previousSignificant: significant,
+        previousSignificant: differenceSignificant,
         previousDifferencePercent: differencePercent,
         previousDifferencePercentMarginOfError: differencePercentMarginOfError,
-        previousPercentSignificant: percentSignificant,
+        previousPercentSignificant: differencePercentSignificant,
         previousChangePercentSignificant: changePercentSignificant,
         previousChangePercentagePoint: changePercentagePoint,
         previousChangePercentagePointMarginOfError: changePercentagePointMarginOfError,
@@ -514,17 +513,17 @@ export default DS.Model.extend({
       return {
         sum,
         direction,
-        moe,
+        marginOfError,
         correlationCoefficient,
         percent,
         percentMarginOfError,
         isReliable,
         differenceSum,
         differenceMarginOfError,
-        significant,
+        differenceSignificant,
         differencePercent,
         differencePercentMarginOfError,
-        percentSignificant,
+        differencePercentSignificant,
         changePercentSignificant,
         changePercentagePoint,
         changePercentagePointMarginOfError,

--- a/app/models/decennial-row.js
+++ b/app/models/decennial-row.js
@@ -340,7 +340,7 @@ export default DS.Model.extend({
    * "significant" actually reflects reliability (calculations were changed in
    * the API but variable names have not been updated, check issue #57)
    */
-  significant: DS.attr('boolean', {
+  differenceSignificant: DS.attr('boolean', {
     defaultValue: true,
   }),
 
@@ -360,7 +360,7 @@ export default DS.Model.extend({
    * percentSignificant reflects reliability (calculations were changed in the
    * API but variable names have not been updated, check issue #57)
    */
-  percentSignificant: DS.attr('boolean', {
+  differencePercentSignificant: DS.attr('boolean', {
     defaultValue: true,
   }),
   /* =====  End of DIFFERENCE_  ====== */

--- a/app/templates/components/data-table-column-group.hbs
+++ b/app/templates/components/data-table-column-group.hbs
@@ -10,7 +10,7 @@
   <td class="{{unless this.model.isReliable 'insignificant'}}">
     {{if
       (and (gt this.model.sum 0) (not this.model.direction))
-        (format-number this.model.moe precision=this.rowConfig.decimal)}}
+        (format-number this.model.marginOfError precision=this.rowConfig.decimal)}}
   </td>
   {{!-- CV --}}
   <td class="{{unless this.model.isReliable 'insignificant'}}">

--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -31,7 +31,7 @@
     class="cell-border-left
     {{if
       (or
-        (not this.data.significant)
+        (not this.data.differenceSignificant)
         (and (eq this.data.sum 0) (eq this.data.comparisonSum 0)))
       'insignificant'}}">
     {{unless (eq this.data.differenceSum null)
@@ -43,7 +43,7 @@
     <td class="
       {{if
         (or
-          (not this.data.significant)
+          (not this.data.differenceSignificant)
           (and (eq this.data.sum 0) (eq this.data.comparisonSum 0)))
         'insignificant'}}">
       {{unless (eq this.data.differenceMarginOfError null)
@@ -52,9 +52,8 @@
             precision=this.rowConfig.decimal)}}
     </td>
   {{/if}}
-
     <td
-      class="{{unless this.data.percentSignificant 'insignificant'}} difference-percent">
+      class="{{unless this.data.differencePercentSignificant 'insignificant'}} difference-percent">
       {{unless (eq this.data.differencePercent null)
           (format-number
             this.data.differencePercent
@@ -62,7 +61,7 @@
     </td>
     {{#if this.reliability}}
       <td
-        class="{{unless this.data.percentSignificant 'insignificant'}} difference-percent-m">
+        class="{{unless this.data.differencePercentSignificant 'insignificant'}} difference-percent-m">
         {{unless (eq this.data.differencePercentMarginOfError null)
           (format-number
             this.data.differencePercentMarginOfError


### PR DESCRIPTION
### Summary
This PR renames some row properties to match the new ones coming back from the API. This fixes an issue where the difference fields weren't being correctly grayed-out based on reliability

#### Tasks/Bug Numbers
 - Fixes [AB#5033](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5033)