### PR TITLE
updating source list copy, fixing issue with missing previous compare, fixing decennial bar chart

### DIFF
--- a/app/chart-config/census/race-group.js
+++ b/app/chart-config/census/race-group.js
@@ -4,15 +4,15 @@ export default [
     label: 'Hispanic',
   },
   {
-    property: 'wtnh',
+    property: 'wnh',
     label: 'White nonhispanic',
   },
   {
-    property: 'blnh',
+    property: 'bnh',
     label: 'Black nonhispanic',
   },
   {
-    property: 'asnnh',
+    property: 'anh',
     label: 'Asian nonhispanic',
   },
 ];

--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { get } from '@ember/object';
+import { get, getWithDefault } from '@ember/object';
 import ResizeAware from 'ember-resize/mixins/resize-aware';
 import { select } from 'd3-selection';
 import { scaleBand, scaleLinear } from 'd3-scale';
@@ -64,6 +64,7 @@ export default Component.extend(ResizeAware, {
     const svg = this.get('svg');
     const data = this.get('data');
     const config = this.get('config');
+    const isDecennial = this.get('survey') === 'census'
 
     const el = this.$();
     const elWidth = el.width();
@@ -90,8 +91,8 @@ export default Component.extend(ResizeAware, {
     }
 
     const xMax = max([
-      max(rawData, d => get(d, 'percent') + get(d, 'percentMarginOfError')),
-      max(rawData, d => get(d, 'comparisonPercent') + get(d, 'comparisonPercentMarginOfError')),
+      max(rawData, d => get(d, 'percent') + getWithDefault(d, 'percentMarginOfError', 0)),
+      max(rawData, d => get(d, 'comparisonPercent') + getWithDefault(d, 'comparisonPercentMarginOfError', 0)),
     ]);
 
     const x = scaleLinear()
@@ -207,83 +208,83 @@ export default Component.extend(ResizeAware, {
 
 
     // draw MOE
-
-    const moebars = svg.selectAll('.moebar')
-      .data(rawData, d => get(d, 'group'));
-
-
-    const xFunctionMOE = (d) => {
-      if (get(d, 'percentMarginOfError') > get(d, 'percent')) return x(0);
-      return x(get(d, 'percent')) - x(get(d, 'percentMarginOfError')) - -textWidth;
-    };
-
-    const widthFunctionMOE = (d) => {
-      const defaultWidth = (x(get(d, 'percentMarginOfError')) - textWidth) * 2;
-      const axesWidth = width - textWidth;
-      const barWidth = x(get(d, 'percent')) - textWidth;
-      if (get(d, 'percentMarginOfError') > get(d, 'percent')) {
-        const newWidth = defaultWidth - (x(get(d, 'percentMarginOfError') - get(d, 'percent')) - textWidth);
-        return newWidth;
-      }
-      // if the percentage bar + the MOE bar extend past 100% on the x axes, modify width of MOE bar
-      if (barWidth + (defaultWidth * 0.5) > axesWidth) {
-        const gapWidth = axesWidth - barWidth;
-        const shortenedWidth = (defaultWidth * 0.5) + gapWidth;
-        return shortenedWidth;
-      }
-
-      return defaultWidth;
-    };
-
-    moebars.enter()
-      .append('rect')
-      .attr('class', d => `moebar ${get(d, 'classValue')}`)
-      .attr('fill', (d) => {
-        if (get(d, 'color')) return get(d, 'color');
-        return '#2e6472';
-      })
-      .attr('opacity', 0.4)
-      .attr('x', xFunctionMOE)
-      .attr('y', d => y(get(d, 'group')) + (y.bandwidth() / 2) + -3)
-      .attr('height', 6)
-      .attr('width', widthFunctionMOE);
-
-    moebars.transition().duration(300)
-      .attr('x', xFunctionMOE)
-      .attr('width', widthFunctionMOE);
-
-    moebars.exit().remove();
-
-
-    // draw Comparison MOE
-
-    const comparisonMOEbars = svg.selectAll('.comparisonMoebar')
-      .data(rawData, d => get(d, 'group'));
-
-    const xFunctionComparisonMOE = d => x(get(d, 'comparisonPercent'))
-      - x(get(d, 'comparisonPercentMarginOfError'))
-      - -textWidth;
-
-    const widthFunctionComparisonMOE = d => (x(get(d, 'comparisonPercentMarginOfError')) - textWidth) * 2;
-    comparisonMOEbars.enter()
-      .append('rect')
-      .attr('class', d => `comparisonMoebar ${get(d, 'classValue')}`)
-      .attr('fill', (d) => {
-        if (get(d, 'color')) return get(d, 'color');
-        return '#000000';
-      })
-      .attr('opacity', 1)
-      .attr('x', xFunctionComparisonMOE)
-      .attr('y', d => y(get(d, 'group')) + (y.bandwidth() / 2) + -0.5)
-      .attr('height', 1)
-      .attr('width', widthFunctionComparisonMOE);
-
-    comparisonMOEbars.transition().duration(300)
-      .attr('x', xFunctionComparisonMOE)
-      .attr('width', widthFunctionComparisonMOE);
-
-    comparisonMOEbars.exit().remove();
-
+    if (!isDecennial) {
+      const moebars = svg.selectAll('.moebar')
+        .data(rawData, d => get(d, 'group'));
+  
+  
+      const xFunctionMOE = (d) => {
+        if (get(d, 'percentMarginOfError') > get(d, 'percent')) return x(0);
+        return x(get(d, 'percent')) - x(get(d, 'percentMarginOfError')) - -textWidth;
+      };
+  
+      const widthFunctionMOE = (d) => {
+        const defaultWidth = (x(get(d, 'percentMarginOfError')) - textWidth) * 2;
+        const axesWidth = width - textWidth;
+        const barWidth = x(get(d, 'percent')) - textWidth;
+        if (get(d, 'percentMarginOfError') > get(d, 'percent')) {
+          const newWidth = defaultWidth - (x(get(d, 'percentMarginOfError') - get(d, 'percent')) - textWidth);
+          return newWidth;
+        }
+        // if the percentage bar + the MOE bar extend past 100% on the x axes, modify width of MOE bar
+        if (barWidth + (defaultWidth * 0.5) > axesWidth) {
+          const gapWidth = axesWidth - barWidth;
+          const shortenedWidth = (defaultWidth * 0.5) + gapWidth;
+          return shortenedWidth;
+        }
+  
+        return defaultWidth;
+      };
+  
+      moebars.enter()
+        .append('rect')
+        .attr('class', d => `moebar ${get(d, 'classValue')}`)
+        .attr('fill', (d) => {
+          if (get(d, 'color')) return get(d, 'color');
+          return '#2e6472';
+        })
+        .attr('opacity', 0.4)
+        .attr('x', xFunctionMOE)
+        .attr('y', d => y(get(d, 'group')) + (y.bandwidth() / 2) + -3)
+        .attr('height', 6)
+        .attr('width', widthFunctionMOE);
+  
+      moebars.transition().duration(300)
+        .attr('x', xFunctionMOE)
+        .attr('width', widthFunctionMOE);
+  
+      moebars.exit().remove();
+  
+  
+      // draw Comparison MOE
+  
+      const comparisonMOEbars = svg.selectAll('.comparisonMoebar')
+        .data(rawData, d => get(d, 'group'));
+  
+      const xFunctionComparisonMOE = d => x(get(d, 'comparisonPercent'))
+        - x(get(d, 'comparisonPercentMarginOfError'))
+        - -textWidth;
+  
+      const widthFunctionComparisonMOE = d => (x(get(d, 'comparisonPercentMarginOfError')) - textWidth) * 2;
+      comparisonMOEbars.enter()
+        .append('rect')
+        .attr('class', d => `comparisonMoebar ${get(d, 'classValue')}`)
+        .attr('fill', (d) => {
+          if (get(d, 'color')) return get(d, 'color');
+          return '#000000';
+        })
+        .attr('opacity', 1)
+        .attr('x', xFunctionComparisonMOE)
+        .attr('y', d => y(get(d, 'group')) + (y.bandwidth() / 2) + -0.5)
+        .attr('height', 1)
+        .attr('width', widthFunctionComparisonMOE);
+  
+      comparisonMOEbars.transition().duration(300)
+        .attr('x', xFunctionComparisonMOE)
+        .attr('width', widthFunctionComparisonMOE);
+  
+      comparisonMOEbars.exit().remove();
+    }
 
     // draw comparison dots
 

--- a/app/components/data-table-row-change.js
+++ b/app/components/data-table-row-change.js
@@ -35,8 +35,11 @@ export default Component.extend({
   }),
 
   noPriorData: computed('data.previous.sum', function() {
-    const { 'data.previous.sum': previousSum } = this.getProperties('data.previous.sum');
-    return previousSum === null;
+    const { 'data.previous': previous } = this.getProperties('data.previous');
+    if ( previous && typeof previous.sum === 'undefined') {
+      return true
+    }
+    return false
   }),
 
   actions: {

--- a/app/sources-config/index.js
+++ b/app/sources-config/index.js
@@ -1,7 +1,7 @@
 export default [
   {
     id: 'decennial-current',
-    label: '2020 Decennial Census',
+    label: '2020',
     type: 'census',
     year: '2020',
     mode: 'current',
@@ -9,7 +9,7 @@ export default [
   },
   {
     id: 'decennial-previous',
-    label: '2010 Decennial Census',
+    label: '2010',
     type: 'census',
     year: '2010',
     mode: 'previous',
@@ -17,7 +17,7 @@ export default [
   },
   {
     id: 'decennial-change',
-    label: 'Change over Time: Decennial Census 2020, 2010',
+    label: 'Change Over Time (2010 to 2020)',
     type: 'census',
     year: null,
     mode: 'change',
@@ -25,7 +25,7 @@ export default [
   },
   {
     id: 'acs-current',
-    label: '2015 - 2019 ACS',
+    label: '2015 - 2019',
     type: 'acs',
     year: '2015-2019',
     mode: 'current',
@@ -33,7 +33,7 @@ export default [
   },
   {
     id: 'acs-previous',
-    label: '2006 - 2010 ACS',
+    label: '2006 - 2010',
     type: 'acs',
     year: '2006-2010',
     mode: 'previous',
@@ -41,7 +41,7 @@ export default [
   },
   {
     id: 'acs-change',
-    label: 'Change over Time: ACS 2006-2010 to 2015-2019',
+    label: 'Change Over Time (2006-2010 to 2015-2019)',
     type: 'acs',
     year: null,
     mode: 'change',

--- a/app/templates/components/acs-bar.hbs
+++ b/app/templates/components/acs-bar.hbs
@@ -15,15 +15,21 @@
 </div> --}}
 <svg class="age-chart-key" width="100%" height="100%">
   <g>
+    {{#if (eq this.survey 'census')}}
+      <rect x="0" y="9" height="11" width="20" rx="2" ry="2" class="bar"></rect>
+      <text fill="#000" x="30" dy="18" style="text-anchor: start;">Selected Area percent</text>
 
-    <rect x="0" y="9" height="11" width="20" rx="2" ry="2" class="bar"></rect>
-    <rect alighnment-baseline="middle" x="15" y="11.5" height="6" width="10" class="moe"></rect>
-    <text fill="#000" x="30" dy="18" style="text-anchor: start;">Selected Area percent and margin of error</text>
+      <circle cx="12.5" cy="30" r="2.5" class="comparison"></circle>
+      <text fill="#000" x="30" dy="33" style="text-anchor: start;">Comparison Area percent</text>
+    {{else}}
+      <rect x="0" y="9" height="11" width="20" rx="2" ry="2" class="bar"></rect>
+      <rect alighnment-baseline="middle" x="15" y="11.5" height="6" width="10" class="moe"></rect>
+      <text fill="#000" x="30" dy="18" style="text-anchor: start;">Selected Area percent and margin of error</text>
 
-    <rect x="2.5" y="29.5" height="1" width="20" class="comparisonmoe"></rect>
-    <circle cx="12.5" cy="30" r="2.5" class="comparison"></circle>
-    <text fill="#000" x="30" dy="33" style="text-anchor: start;">Comparison Area percent and margin of error</text>
-
+      <rect x="2.5" y="29.5" height="1" width="20" class="comparisonmoe"></rect>
+      <circle cx="12.5" cy="30" r="2.5" class="comparison"></circle>
+      <text fill="#000" x="30" dy="33" style="text-anchor: start;">Comparison Area percent and margin of error</text>
+    {{/if}}
   </g>
 </svg>
 {{yield}}

--- a/app/templates/components/data-table-header-change.hbs
+++ b/app/templates/components/data-table-header-change.hbs
@@ -39,7 +39,7 @@
             Percent
             {{fa-icon icon='question-circle' transform='shrink-2'}}
             {{ember-tooltip
-              text='2014-2018 number minus 2006-2010 number, divided by 2006-2010 number. Quotient multiplied by 100.'
+              text='2015-2019 number minus 2006-2010 number, divided by 2006-2010 number. Quotient multiplied by 100.'
               side='left'
             }}
           </span>
@@ -141,7 +141,7 @@
             MOE
             {{fa-icon icon='question-circle' transform='shrink-2'}}
             {{ember-tooltip
-              text='2010 number minus 2000 number, divided by 2000 number. Quotient multiplied by 100.'
+              text='2020 number minus 2010 number, divided by 2010 number. Quotient multiplied by 100.'
               side='left'
             }}
           </span>
@@ -159,7 +159,7 @@
             Percent
             {{fa-icon icon='question-circle' transform='shrink-2'}}
             {{ember-tooltip
-              text='2010 number minus 2000 number, divided by 2000 number. Quotient multiplied by 100.'
+              text='2020 number minus 2010 number, divided by 2010 number. Quotient multiplied by 100.'
               side='left'
             }}
           </span>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -100,6 +100,7 @@
                   {{acs-bar
                     title=chart.chartLabel
                     config=chart.chartConfig
+                    survey=this.source.type
                     data=this.surveyData
                     height=204
                   }}
@@ -144,6 +145,7 @@
                     {{acs-bar
                       title=chart.chartLabel
                       config=chart.chartConfig
+                      survey=this.source.type
                       data=this.surveyData
                       height=204
                     }}


### PR DESCRIPTION
### Summary
This PR Fixes three bugs. One is just updating the text in the survey selection dropdown and some tooltips to reflect the new census years. Another was an issue where zeros were showing for nonexistent comparison variables in the data explorer instead of the user friendly text that should appear. The last is improving the bar chart component to work with decennial data.

#### Tasks/Bug Numbers
 - Fixes [AB#5065](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5065)
 - Fixes [AB#5023](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5023)
 - Fixes [AB#5117](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5117)
