### PR TITLE
4542 Fix for selections being cutoff at tile boundaries

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -16,6 +16,13 @@
 
  {{!--  TURN THIS OFF TO GET RID OF THE MAP  --}}
 <div class="map-container">
+  {{#if this.selection.getEntireGeoTask.isRunning}}
+    <div class="spinner">
+      <div class="bounce"></div>
+      <div class="bounce"></div>
+      <div class="bounce"></div>
+    </div>
+  {{/if}}
   <LabsMap 
     @id="map"
     @sources={{this.sources}}


### PR DESCRIPTION
### Summary
Previously, user selections of large geographies like CDTAs and Boundaries would get cut off at tile boundaries. 

It turns out this is known behavior with the mapbox-gl issue. When accessing the geometry through the click event, that geometry data is clipped at the tile edges. 

The temporary workaround here is to grab the geoid of the clicked geography, and make a second request to Carto for the entire geography. 

I limited this workaround to just CDTAs, Boroughs, Districts and Cities since those are the only ones exhibiting the issue. Also, for the other geos there is an attribute mismatch between the summary level table queries and the layer sources (from the Layers API), which causes some errors.

#### Tasks/Bug Numbers
 - Fixes [AB#4542](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4542)

### Technical Explanation

