### PR TITLE
Fixing moe variable naming bug

### DIFF
--- a/app/models/acs-row.js
+++ b/app/models/acs-row.js
@@ -543,7 +543,7 @@ export default DS.Model.extend({
         const {
           previousComparisonSum: sum,
           previousComparisonCodingThreshold: direction,// TODO: fix namespace conflict
-          previousComparisonMarginOfError: m,
+          previousComparisonMarginOfError: moe,
           previousComparisonCorrelationCoefficient: correlationCoefficient,
           previousComparisonPercent: percent,
           previousComparisonPercentMarginOfError: percentMarginOfError,
@@ -561,7 +561,7 @@ export default DS.Model.extend({
         return {
           sum,
           direction,
-          m,
+          moe,
           correlationCoefficient,
           percent,
           percentMarginOfError,

--- a/app/models/decennial-row.js
+++ b/app/models/decennial-row.js
@@ -567,7 +567,7 @@ export default DS.Model.extend({
         const {
           previousComparisonSum: sum,
           previousComparisonCodingThreshold: direction,// TODO: fix namespace conflict
-          previousComparisonMarginOfError: m,
+          previousComparisonMarginOfError: moe,
           previousComparisonCorrelationCoefficient: correlationCoefficient,
           previousComparisonPercent: percent,
           previousComparisonPercentMarginOfError: percentMarginOfError,
@@ -585,7 +585,7 @@ export default DS.Model.extend({
         return {
           sum,
           direction,
-          m,
+          moe,
           correlationCoefficient,
           percent,
           percentMarginOfError,


### PR DESCRIPTION
### Summary
This PR fixes a bug where previous comparison MOEs were showing up as 0 because a variable was incorrectly named.

#### Tasks/Bug Numbers
 - Fixes [AB#5189](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5189)
