### PR TITLE
Fixing moe var naming

### DIFF
--- a/app/models/acs-row.js
+++ b/app/models/acs-row.js
@@ -426,7 +426,7 @@ export default DS.Model.extend({
     function() {
       const {
         comparisonSum: sum,
-        comparisonMarginOfError: moe,
+        comparisonMarginOfError: marginOfError,
         comparisonCorrelationCoefficient: correlationCoefficient,
         comparisonPercent: percent,
         comparisonPercentMarginOfError: percentMarginOfError,
@@ -443,7 +443,7 @@ export default DS.Model.extend({
       );
 
       return {
-        sum, moe, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
+        sum, marginOfError, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
       };
     },
   ),
@@ -543,7 +543,7 @@ export default DS.Model.extend({
         const {
           previousComparisonSum: sum,
           previousComparisonCodingThreshold: direction,// TODO: fix namespace conflict
-          previousComparisonMarginOfError: moe,
+          previousComparisonMarginOfError: marginOfError,
           previousComparisonCorrelationCoefficient: correlationCoefficient,
           previousComparisonPercent: percent,
           previousComparisonPercentMarginOfError: percentMarginOfError,
@@ -561,7 +561,7 @@ export default DS.Model.extend({
         return {
           sum,
           direction,
-          moe,
+          marginOfError,
           correlationCoefficient,
           percent,
           percentMarginOfError,

--- a/app/models/decennial-row.js
+++ b/app/models/decennial-row.js
@@ -412,7 +412,7 @@ export default DS.Model.extend({
     function() {
       const {
         sum,
-        m: moe,
+        marginOfError,
         correlationCoefficient,
         percent,
         percentMarginOfError,
@@ -429,7 +429,7 @@ export default DS.Model.extend({
       );
 
       return {
-        sum, moe, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
+        sum, marginOfError, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
       };
     },
   ),
@@ -450,7 +450,7 @@ export default DS.Model.extend({
     function() {
       const {
         comparisonSum: sum,
-        comparisonMarginOfError: moe,
+        comparisonMarginOfError: marginOfError,
         comparisonCorrelationCoefficient: correlationCoefficient,
         comparisonPercent: percent,
         comparisonPercentMarginOfError: percentMarginOfError,
@@ -467,7 +467,7 @@ export default DS.Model.extend({
       );
 
       return {
-        sum, moe, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
+        sum, marginOfError, correlationCoefficient, percent, percentMarginOfError, isReliable, direction,
       };
     },
   ),
@@ -499,7 +499,7 @@ export default DS.Model.extend({
       const {
         previousSum: sum,
         previousCodingThreshold: direction, // TODO: fix naming
-        previousMarginOfError: moe,
+        previousMarginOfError: marginOfError,
         previousCorrelationCoefficient: correlationCoefficient,
         previousPercent: percent,
         previousPercentMarginOfError: percentMarginOfError,
@@ -537,7 +537,7 @@ export default DS.Model.extend({
       return {
         sum,
         direction,
-        moe,
+        marginOfError,
         correlationCoefficient,
         percent,
         percentMarginOfError,
@@ -567,7 +567,7 @@ export default DS.Model.extend({
         const {
           previousComparisonSum: sum,
           previousComparisonCodingThreshold: direction,// TODO: fix namespace conflict
-          previousComparisonMarginOfError: moe,
+          previousComparisonMarginOfError: marginOfError,
           previousComparisonCorrelationCoefficient: correlationCoefficient,
           previousComparisonPercent: percent,
           previousComparisonPercentMarginOfError: percentMarginOfError,
@@ -585,7 +585,7 @@ export default DS.Model.extend({
         return {
           sum,
           direction,
-          moe,
+          marginOfError,
           correlationCoefficient,
           percent,
           percentMarginOfError,


### PR DESCRIPTION
### Summary
This PR fixes some more bugs related to property renaming. Due to some branches that hadn't been tested in aggregate before deploying (my bad) data in the explorer page wasn't showing up.

