### PR TITLE
5190 default selection for choropleth

### DIFF
--- a/app/components/layer-menu-item.js
+++ b/app/components/layer-menu-item.js
@@ -9,6 +9,21 @@ export default Component.extend({
     const foundRecord = this.get('store').peekRecord('layer-group', recordIdentifier);
 
     if (foundRecord) {
+      foundRecord.set('layers', foundRecord.layers.map(layer => {
+        if(layer.id === 'choropleth-nta-fill') {
+          layer.paint = {
+            ...layer.paint,
+            ...this.defaultFill
+          }
+        }
+        if(layer.id === 'choropleth-nta-line') {
+          layer.paint = {
+            ...layer.paint,
+            ...this.defaultLine
+          }
+        }
+        return layer
+      }))
       this.set('model', foundRecord);
     }
   },

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -89,7 +89,11 @@
     {{#if (eq @mode 'direct-select')}}
       <div class="more-options {{unless this.advanced 'closed'}}" style="color:black">
         {{#unless this.closed}}
-              {{#layer-menu-item for='choropleths' as |layerGroup|}}
+              {{#layer-menu-item
+                defaultFill=this.choroplethPaintFill
+                defaultLine=this.choroplethPaintLine
+                for='choropleths' as |layerGroup|
+              }}
                 {{#if layerGroup.model.visible}}
                   <div class="grid-x">
                     <div class="cell small-8">


### PR DESCRIPTION
### Summary
This PR fixes a bug where the choropleth colors weren't correctly defaulting to showing population density when thematic maps are switched on

#### Tasks/Bug Numbers
 - Fixes [AB#5190](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5190)
