### PR TITLE
5112 set reliability to false for census data tables

### DIFF
--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -77,8 +77,8 @@
               </h3>
               {{data-table
                 mode=this.mode
-                decennial=(eq this.source.type 'census')
-                reliability=this.showReliability
+                decennial=true
+                reliability=false
                 comparison=this.compareTo
                 compareToLabel=this.comparisonGeo.label
                 config=subtopic.tableConfig
@@ -125,7 +125,7 @@
                 </h3>
                 {{data-table
                   mode=this.mode
-                  decennial=(eq this.source.type 'census')
+                  decennial=false
                   reliability=this.showReliability
                   comparison=this.compareTo
                   compareToLabel=this.comparisonGeo.label


### PR DESCRIPTION
### Summary
We previously only disabled the Show Reliability  toggle when the source is census. This  PR forces the `decennial` argument to the data-table to be `false` for census tables. 

#### Tasks/Bug Numbers
 - Fixes [AB#5112](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5112)
