### PR TITLE
5194 Fixing typo in choropleth id

### DIFF
--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -44,7 +44,7 @@ const choroplethConfigs = [
   },
   {
     group: 'Social (ACS)',
-    id: 'lgoenlep',
+    id: 'lgoenlep1',
     label: 'Limited English Proficiency (LEP)',
     tooltip: 'Population 5 years and over who speak English "less than very well"',
     legendTitle: 'Population 5 years and over who speak English "less than very well"',


### PR DESCRIPTION
### Summary
This PR fixes a typo in a choropleth config

#### Tasks/Bug Numbers
 - Fixes [AB#5194](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5194)