### PR TITLE
5117 Fixing logic to show bar chart for all non-change over time sources

### DIFF
--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -90,7 +90,7 @@
             {{#if (and
               (or
                 (eq this.source.id 'decennial-current')
-                (eq this.source.id 'decennial-change')
+                (eq this.source.id 'decennial-previous')
               )
               subtopic.charts
               this.showCharts
@@ -136,7 +136,10 @@
               </div>
 
               {{#if (and
-                (eq this.mode 'current')
+                (or
+                  (eq this.source.id 'acs-current')
+                  (eq this.source.id 'acs-previous')
+                )
                 subtopic.charts
                 this.showCharts
               )}}


### PR DESCRIPTION
### Summary
This PR updates the explorer page so that charts can only be shown for non-change over time sources

#### Tasks/Bug Numbers
 - Fixes [AB#5117](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5117)