### PR TITLE
5113 Display census avg household size w 2 decimal places

### DIFF
--- a/app/table-config/census/population-density.js
+++ b/app/table-config/census/population-density.js
@@ -18,6 +18,7 @@ export default [
   {
     data: 'avghhsz',
     title: 'Average household size',
+    decimal: 2,
   },
   {
     data: 'popperacre',


### PR DESCRIPTION
### Summary
Thankfully turns out there is already a pattern set up to set decimal places for specific variables. I discarded the ad-hoc conditional  idea. @SPTKL 

#### Tasks/Bug Numbers
 - Fixes [AB#5113](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5113)
