### PR TITLE
5055 Fix significant arrow logic

### DIFF
--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -31,18 +31,14 @@
         precision=@rowConfig.decimal
       }}
 
-      {{#if (and
-        (gt @data.changeSum 0)
-        (lt @data.changeMarginOfError (abs @data.changeSum))
-      )}}
-        {{fa-icon icon="arrow-up" class="green"}}
-      {{else if (and
-        (lt @data.changeSum 0)
-        (lt @data.changeMarginOfError (abs @data.changeSum))
-      )}}
-        {{fa-icon icon="arrow-down" class="red"}}
-      {{else}}
-        {{fa-icon icon=""}}
+      {{#if (lt @data.changeMarginOfError (abs @data.changeSum))}}
+        {{#if (gt @data.changeSum 0)}}
+          {{fa-icon icon="arrow-up" class="green"}}
+        {{else if (lt @data.changeSum 0)}}
+          {{fa-icon icon="arrow-down" class="red"}}
+        {{else}}
+          {{fa-icon icon=""}}
+        {{/if}}
       {{/if}}
     {{/unless}}
   </td>
@@ -65,18 +61,14 @@
         '%'
       }}
 
-      {{#if (and
-        (gt @data.changePercent 0)
-        (lt @data.changePercentMarginOfError (abs @data.changePercent))
-      )}}
-        {{fa-icon icon="arrow-up" class="green"}}
-      {{else if (and
-        (lt @data.changePercent 0)
-        (lt @data.changePercentMarginOfError (abs @data.changePercent))
-      )}}
-        {{fa-icon icon="arrow-down" class="red"}}
-      {{else}}
-        {{fa-icon icon=""}}
+      {{#if (lt @data.changePercentMarginOfError (abs @data.changePercent))}}
+        {{#if (gt @data.changePercent 0)}}
+          {{fa-icon icon="arrow-up" class="green"}}
+        {{else if (lt @data.changePercent 0)}}
+          {{fa-icon icon="arrow-down" class="red"}}
+        {{else}}
+          {{fa-icon icon=""}}
+        {{/if}}
       {{/if}}
     {{/unless}}
   </td>
@@ -105,18 +97,14 @@
         (mult @data.changePercentagePoint 100)
         precision=1}}
 
-      {{#if (and
-        (gt @data.changePercentagePoint 0)
-        (lt @data.changePercentagePointMarginOfError (abs @data.changePercentagePoint))
-      )}}
-        {{fa-icon icon="arrow-up" class="green"}}
-      {{else if (and
-        (lt @data.changePercentagePoint 0)
-        (lt @data.changePercentagePointMarginOfError (abs @data.changePercentagePoint))
-      )}}
-        {{fa-icon icon="arrow-down" class="red"}}
-      {{else}}
-        {{fa-icon icon=""}}
+      {{#if (lt @data.changePercentagePointMarginOfError (abs @data.changePercentagePoint))}}
+        {{#if (gt @data.changePercentagePoint 0)}}
+          {{fa-icon icon="arrow-up" class="green"}}
+        {{else if (lt @data.changePercentagePoint 0)}}
+          {{fa-icon icon="arrow-down" class="red"}}
+        {{else}}
+          {{fa-icon icon=""}}
+        {{/if}}
       {{/if}}
     {{/unless}}
   </td>


### PR DESCRIPTION
### Summary
Previously the significant arrow logic did not use the absolute value for the change value, as it should. 
Also the down arrow condition used `gt` instead of `lt` as it should. 

This PR fixes both. 

#### Tasks/Bug Numbers
 - Fixes [AB#5055](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5055)