### PR TITLE
5143 Remove unhelpful  transitionTo that threw exception

### DIFF
--- a/app/components/map-search.js
+++ b/app/components/map-search.js
@@ -171,7 +171,7 @@ export default Component.extend({
         this.set('searchTerms', result.feature.properties.fips);
         this.fitBounds(result.feature, 0.5);
       }
-      //
+
       if (result.type === 'nta') {
         selection.set('searchResultFeature', result.feature);
         this.set('searchTerms', result.feature.properties.ntacode);
@@ -189,7 +189,6 @@ export default Component.extend({
         selection.set('currentAddress', center);
 
         this.set('searchTerms', result.label);
-        this.transitionTo('index');
 
         if (map) {
           map.flyTo({


### PR DESCRIPTION
### Summary
The transitionTo that fired on address selection is no longer a valid function, so threw an exception.  This blocked the map from zooming to the selected address.

Seems like `transitionTo('index')` was not really useful for anything, anyway.

#### Tasks/Bug Numbers
 - Fixes [AB#5143](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5143)
