### PR TITLE
5322 Selection state does not appear to maintain for CDs

### DIFF
--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -174,6 +174,8 @@ export default Service.extend({
       } else if (fromLevel === 'cities') {
         // If from cities, select all items of toLevel
         this.explodeFromCity(toLevel);
+      } else if ((fromLevel === 'districts') && (toLevel === 'districts')) {
+        // This is to maintain the selection of districts when switching back to the map page from the data explorer page
       } else if ((fromLevel === 'districts') || (toLevel === 'districts')) {
         // District transitions should clear selection
         this.clearSelection();


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This fix makes it so that when you toggle back to the map view from the data explorer, your selection will have been retained. Previously, it was not retaining the selection for CDs.

#### Tasks/Bug Numbers
 - Fixes [AB#5322](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5322)
 - 
### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
