### PR TITLE
5122 (Update) Fix CDTA spacing, NYC selection

### DIFF
--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -6,15 +6,18 @@
       </div>
       <div class="map-utility-box-body">
         <p>
-          <strong>{{this.selectionCount}}</strong>
-          {{if (eq this.selection.summaryLevel 'tracts') 'Tract'~}}
-          {{if (eq this.selection.summaryLevel 'blocks') 'Block'~}}
-          {{if (eq this.selection.summaryLevel 'cdtas') 'CDTA'~}}
-          {{if (eq this.selection.summaryLevel 'districts') 'CD'~}}
-          {{if (eq this.selection.summaryLevel 'ntas') 'NTA'~}}
-          {{if (eq this.selection.summaryLevel 'boroughs') 'Borough'~}}
-          {{if (eq this.selection.summaryLevel 'cities')  'New York City'~}}
-          {{unless (eq this.selectionCount 1) 's'}}
+          {{#if (eq this.selection.summaryLevel 'cities')}}
+            New York City
+          {{else}}
+            <strong>{{this.selectionCount}}</strong>
+            {{if (eq this.selection.summaryLevel 'tracts') 'Tract'~}}
+            {{if (eq this.selection.summaryLevel 'blocks') 'Block'~}}
+            {{if (eq this.selection.summaryLevel 'cdtas') 'CDTA'~}}
+            {{if (eq this.selection.summaryLevel 'districts') 'CD'~}}
+            {{if (eq this.selection.summaryLevel 'ntas') 'NTA'~}}
+            {{if (eq this.selection.summaryLevel 'boroughs') 'Borough'~}}
+            {{unless (eq this.selectionCount 1) 's'}}
+          {{/if}}
           selected
         </p>
       </div>

--- a/app/templates/components/orange-bar-custom-map-study.hbs
+++ b/app/templates/components/orange-bar-custom-map-study.hbs
@@ -52,7 +52,7 @@
             <li class="{{if (eq this.selection.summaryLevel 'cdtas') 'active'}} explode-cdta" style="font-size: 0.75rem;">
               <a href="#" data-test-toggle-cdtas {{action this.handleSummaryLevelToggle 'cdtas'}} style="padding:0;">
                 <span class="show-for-medium">Community<br />District <br /></span>
-                Tabulation Area<small>(CDTA)</small>
+                Tabulation Area <small>(CDTA)</small>
               </a>
               {{ember-tooltip delay=500 text='Create selection area using census cdtas'}}
             </li>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This adds a space before "(CDTA)" on the menu bar, and changes the selection description in the map utility box when NYC is selected, as described in this comment: https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/5122#5060364

#### Tasks/Bug Numbers
 - Fixes [AB#5122](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5122)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
