### PR TITLE
5021 (FIX) Geography selection is showing count rather than geography id

### DIFF
--- a/app/templates/components/select-geography-list-boroughs.hbs
+++ b/app/templates/components/select-geography-list-boroughs.hbs
@@ -2,7 +2,7 @@
   {{#each this.sortedLabels as |boro|}}
     {{#if boro.features.length}}
       {{boro.label}}
-      {{~unless (eq boro.lastObject.properties.geoid boro.properties.geoid) ','}}
+      {{~unless (eq this.sortedLabels.lastObject.label boro.label) ','}}
     {{/if}}
   {{/each}}
 </ul>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This adds a comma between boroughs when borough is the selection type.

#### Tasks/Bug Numbers
 - Fixes [AB#5021](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5021)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
