### PR TITLE
5341 await all get geo tasks

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -170,7 +170,7 @@ export default Controller.extend({
     const selection = this.get('selection');
 
     if (!this.get('isDrawing')) {
-      selection.handleSelectedFeatures([feature]);
+      selection.handleSelectedFeatures.perform([feature]);
     }
   },
 
@@ -200,7 +200,7 @@ export default Controller.extend({
 
     carto.SQL(SQL, 'geojson', 'post')
       .then((FC) => {
-        selection.handleSelectedFeatures(FC.features);
+        selection.handleSelectedFeatures.perform(FC.features);
 
         this.get('metrics').trackEvent('GoogleAnalytics', {
           eventCategory: 'Draw',


### PR DESCRIPTION
### Summary
This is a fix for when using the radius and polygon draw tools when the selection type is CDTA, CD, or Boro.  It was previously selecting only a single item in the selection, rather than all of them.  

Previously we configured `getEntireGeoTask` to be "restartable", meaning only one task for acquiring geometries occurred at a time.  This was fine for selecting single geometries, but when a user uses a drawing tool then multiple geometries are selected. This causes multiple `getEntireGeoTask` to be fired, and each one cancelling the last.

Here we modify the task to essential "await all" `getEntireGeoTask`s that are fired. 

We also remove the use of `selected` in favor of directly using `this.get('current')` for compatibility with ember magic.

#### Tasks/Bug Numbers
 - Fixes AB#5431
