### PR TITLE
5254 Tooltips in the bottom row are unreadable

### DIFF
--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -4,7 +4,11 @@
       {{@rowConfig.title}}
       {{#if @rowConfig.tooltip}}
         {{fa-icon icon='question-circle' transform='shrink-2'}}
-        {{ember-tooltip text=@rowConfig.tooltip side='right'}}
+        {{#if (eq this.rowConfig.title 'Median earnings for workers (dollars)')}}
+          {{ember-tooltip text=this.rowConfig.tooltip side='right'}}
+        {{else}}
+          {{ember-tooltip text=this.rowConfig.tooltip side='top-start'}}
+        {{/if}}
       {{/if}}
     </span>
   </td>

--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -4,7 +4,11 @@
       {{this.rowConfig.title}}
       {{#if this.rowConfig.tooltip}}
         {{fa-icon icon='question-circle' transform='shrink-2'}}
-        {{ember-tooltip text=this.rowConfig.tooltip side='right'}}
+        {{#if (eq this.rowConfig.title 'Median earnings for workers (dollars)')}}
+          {{ember-tooltip text=this.rowConfig.tooltip side='right'}}
+        {{else}}
+          {{ember-tooltip text=this.rowConfig.tooltip side='top-start'}}
+        {{/if}}
       {{/if}}
     </span>
   </td>

--- a/app/templates/components/data-table-row-previous.hbs
+++ b/app/templates/components/data-table-row-previous.hbs
@@ -4,7 +4,11 @@
       {{this.rowConfig.title}}
       {{#if this.rowConfig.tooltip}}
         {{fa-icon icon='question-circle' transform='shrink-2'}}
-        {{ember-tooltip text=this.rowConfig.tooltip side='right'}}
+        {{#if (eq this.rowConfig.title 'Median earnings for workers (dollars)')}}
+          {{ember-tooltip text=this.rowConfig.tooltip side='right'}}
+        {{else}}
+          {{ember-tooltip text=this.rowConfig.tooltip side='top-start'}}
+        {{/if}}
       {{/if}}
     </span>
   </td>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Tooltips in the bottom row were cut off at the bottom.  This fix moves the tooltips from the right of the target to above the target, with the exception of the single instance of a tooltip that is on the top row of the table.

#### Tasks/Bug Numbers
 - Fixes [AB#5254](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5254)

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
