### PR TITLE
5369 Remove fill color for NTAs w/o data in Thematic choropleths

### DIFF
--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -398,9 +398,15 @@ const builtConfigs = choroplethConfigs.map((config) => {
     stops,
     paintFill: {
       'fill-color': [
-        'step',
-        ['get', id],
-        ...stops,
+        "match",
+        ['typeof', ['get', id]],
+        "number",
+        [
+          'step',
+          ['get', id],
+          ...stops,
+        ],
+        ["rgba", 0, 0, 0, 0]
       ],
     },
     paintLine: {


### PR DESCRIPTION
### Summary
Use [Mapbox GL JS style expressions](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/) to conditionally assign the choropleth step function to NTA paintFill. Only makes the assignment if the NTA data value is a number, not null or undefined. 


#### Tasks/Bug Numbers
 - Fixes [AB#5369](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5369)

