### PR TITLE
5382 Disable percent change Choropleths for now bc requires extra processing

### DIFF
--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -344,42 +344,42 @@ const choroplethConfigs = [
     isPercent: true,
     stops: ['#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
   },
-  {
-    group: 'Census',
-    id: 'wnh_pc',
-    label: 'White Non-Hispanic (percent change)',
-    tooltip: 'Percent change in the White Non-Hispanic population, 2010 to 2020',
-    legendTitle: 'White Non-Hispanic (percent change)',
-    isPercent: true,
-    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
-  },
-  {
-    group: 'Census',
-    id: 'bnh_pc',
-    label: 'Black Non-Hispanic (percent change)',
-    tooltip: 'Percent change in the Black Non-Hispanic population, 2010 to 2020',
-    legendTitle: 'Black Non-Hispanic (percent change)',
-    isPercent: true,
-    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476']
-  },
-  {
-    group: 'Census',
-    id: 'anh_pc',
-    label: 'Asian Non-Hispanic (percent change)',
-    tooltip: 'Percent change in the Asian Non-Hispanic population, 2010 to 2020',
-    legendTitle: 'Asian Non-Hispanic (percent change)',
-    isPercent: true,
-    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
-  },
-  {
-    group: 'Census',
-    id: 'hsp1_pc',
-    label: 'Hispanic (percent change)',
-    tooltip: 'Percent change in the Hispanic population, 2010 to 2020',
-    legendTitle: 'Hispanic (percent change)',
-    isPercent: true,
-    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
-  },
+  // {
+  //   group: 'Census',
+  //   id: 'wnh_pc',
+  //   label: 'White Non-Hispanic (percent change)',
+  //   tooltip: 'Percent change in the White Non-Hispanic population, 2010 to 2020',
+  //   legendTitle: 'White Non-Hispanic (percent change)',
+  //   isPercent: true,
+  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
+  // },
+  // {
+  //   group: 'Census',
+  //   id: 'bnh_pc',
+  //   label: 'Black Non-Hispanic (percent change)',
+  //   tooltip: 'Percent change in the Black Non-Hispanic population, 2010 to 2020',
+  //   legendTitle: 'Black Non-Hispanic (percent change)',
+  //   isPercent: true,
+  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476']
+  // },
+  // {
+  //   group: 'Census',
+  //   id: 'anh_pc',
+  //   label: 'Asian Non-Hispanic (percent change)',
+  //   tooltip: 'Percent change in the Asian Non-Hispanic population, 2010 to 2020',
+  //   legendTitle: 'Asian Non-Hispanic (percent change)',
+  //   isPercent: true,
+  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
+  // },
+  // {
+  //   group: 'Census',
+  //   id: 'hsp1_pc',
+  //   label: 'Hispanic (percent change)',
+  //   tooltip: 'Percent change in the Hispanic population, 2010 to 2020',
+  //   legendTitle: 'Hispanic (percent change)',
+  //   isPercent: true,
+  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
+  // },
 ];
 
 const builtConfigs = choroplethConfigs.map((config) => {


### PR DESCRIPTION
### Summary
Disabling the maps for now because this requires extra data-preprocessing. We have the choropleth data pre-processed right now in labs-layers-api/data/sources/choropleths.json. We need to reprocess this to (potentially) assign a string value of "low-population" to the NTAs with population less than 5000. We need to rewrite the choropleth python to accomodate population variable. 

Then we can update the choropleth styling and add an extra conditional styling for the "low-population" value 

Alternate option: frontend code that runs through NTA layer and adds gray polygons above those respective NTAs 

We'll also need to figure out how to add an ad-hoc legend item for these 5 thematic maps 

#### Tasks/Bug Numbers
 - Fixes [AB#5382](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5382)
