### PR TITLE
Adding mobile warning modal and fix mail icon color

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -249,15 +249,6 @@ button {
   }
 }
 
-
-//
-// Site Header - External links
-// --------------------------------------------------
-.external-nav-item {
-  a { color: $light-gray !important;}
-  a:hover { color: $primary-color !important; }
-}
-
 //
 // Profiles
 // --------------------------------------------------

--- a/app/styles/modules/_m-reveal-modal.scss
+++ b/app/styles/modules/_m-reveal-modal.scss
@@ -6,6 +6,12 @@
   z-index: 3;
 }
 
+@include breakpoint(1280px up) {
+  #reveal-modal-container {
+    display: none;
+  }
+}
+
 .reveal-overlay {
   padding: 1rem;
 
@@ -27,6 +33,7 @@
   border: 0;
   box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);
   top: 0;
+  border-radius: 5px;
 
   &:focus {
     outline: none;

--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,10 +1,9 @@
 <RevealModal @open={{this.open}} @closeModal={{action 'toggleModal'}}>
-  <h1 class="header-xlarge">
-    A note to our users about upcoming changes:
+  <h1 class="header-large">
+    NYC Population FactFinder is not optimized for mobile devices. 
   </h1>
 
   <p class="lead">
-    2020 Census Operations include the revision of small area geographies, such as census blocks and census tracts. Accordingly, City Planning will update Neighborhood Tabulation Areas (NTAs), which rely upon these census geographies. City Planning will also release a new geography, to be known as Community District Tabulation Areas (CDTAs), to better approximate New York City’s 59 Community Districts. Look for more details concerning NTAs and CDTAs to be posted in the coming months.
+    Please use a desktop computer for the best experience.
   </p>
-  
 </RevealModal>

--- a/app/templates/components/reveal-modal.hbs
+++ b/app/templates/components/reveal-modal.hbs
@@ -1,6 +1,6 @@
-{{#if this.open}}
+{{#if @open}}
   <div class="reveal-overlay" style="display:block;">
-    <div class="reveal-overlay-target" {{action this.closeModal}}></div>
+    <div class="reveal-overlay-target" {{action @closeModal}}></div>
     <div
       class="reveal"
       role="dialog"
@@ -10,7 +10,7 @@
       data-test-confirmation-modal
     >
       {{yield}}
-      <button {{action this.closeModal}} class="close-button" aria-label="Close modal" type="button">
+      <button {{action @closeModal}} class="close-button" aria-label="Close modal" type="button">
         <span aria-hidden="true">&times;</span>
       </button>
     </div>


### PR DESCRIPTION
### Summary
This PR adds back `default-modal` to show mobile users a warning. Note it is hidden via a media query on screens 1280px or above