### PR TITLE
5409 Data download doesn't include list of selected geographies

### DIFF
--- a/app/components/explorer/download-data-dropdown.js
+++ b/app/components/explorer/download-data-dropdown.js
@@ -101,15 +101,17 @@ export default class DownloadDataDropdown extends Component{
     var rowspanText;
 
     var rows = document.querySelectorAll("h3, table tr");
+    const geoCount = document.querySelector("h2");
+    const geoSelection = document.querySelector(".profile-geographies .comma-separated-list");
+    if (geoCount) { csv.push(this.actions.convertStringForCSV(geoCount.innerText)); }
+    if (geoSelection) { csv.push(this.actions.convertStringForCSV(geoSelection.innerText)); }
     
     for (var i = 0; i < rows.length; i++) {
       var row = [];
 
       if (rows[i].nodeName === "H3") {
-        //add two blank rows above all but the first table
-        if (i>0) {
-          csv.push(null, null);
-        }
+        //add two blank rows above each table
+        csv.push(null, null);
         row.push(this.actions.convertStringForCSV(rows[i].innerText));
 
       } else {


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Added number of geos selected and list of selected geos (as they appear on the data explorer page) to the csv download.

#### Tasks/Bug Numbers
 - Fixes [AB#5409](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5409)

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
