### PR TITLE
5382 Re-add racial percent change choropleths and add logic for ntas below…

### DIFF
--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -299,6 +299,7 @@ const choroplethConfigs = [
     label: 'Population (change)',
     tooltip: 'Population change, 2010 to 2020',
     legendTitle: 'Population (change)',
+    isChange: true,
     stops: ['#c81d00',-5000,'#f46c59',-1000,'#ffc0b4',-500,'#ffffff',500,'#b5d5e5',1000,'#0473ad',5000,'#0b5476',10000,'#012661'],
   },
   {
@@ -307,6 +308,7 @@ const choroplethConfigs = [
     label: 'White Non-Hispanic (change)',
     tooltip: 'White non-Hispanic population change, 2010 to 2020',
     legendTitle: 'White Non-Hispanic (change)',
+    isChange: true,
     stops: ['#c81d00',-5000,'#f46c59',-1000,'#ffc0b4',-500,'#ffffff',500,'#b5d5e5',1000,'#0473ad',5000,'#0b5476',10000,'#012661'],
   },
   {
@@ -315,6 +317,7 @@ const choroplethConfigs = [
     label: 'Black Non-Hispanic (change)',
     tooltip: 'Black non-Hispanic population change, 2010 to 2020',
     legendTitle: 'Black Non-Hispanic (change)',
+    isChange: true,
     stops: ['#c81d00',-5000,'#f46c59',-1000,'#ffc0b4',-500,'#ffffff',500,'#b5d5e5',1000,'#0473ad'],
 
   },
@@ -324,6 +327,7 @@ const choroplethConfigs = [
     label: 'Asian Non-Hispanic (change)',
     tooltip: 'Asian non-Hispanic population change, 2010 to 2020',
     legendTitle: 'Asian Non-Hispanic (change)',
+    isChange: true,
     stops: ['#c81d00',-5000,'#f46c59',-1000,'#ffc0b4',-500,'#ffffff',500,'#b5d5e5',1000,'#0473ad',5000,'#0b5476',10000,'#012661'],
   },
   {
@@ -332,15 +336,17 @@ const choroplethConfigs = [
     label: 'Hispanic (change)',
     tooltip: 'Hispanic population change, 2010 to 2020',
     legendTitle: 'Hispanic (change)',
+    isChange: true,
     stops: ['#c81d00',-5000,'#f46c59',-1000,'#ffc0b4',-500,'#ffffff',500,'#b5d5e5',1000,'#0473ad',5000,'#0b5476'],
   },
   // Percent Change
   {
     group: 'Census',
-    id: 'popu18_1_pc',
+    id: 'pop1_pc',
     label: 'Population (percent change)',
     tooltip: 'Percent change in population, 2010 to 2020',
     legendTitle: 'Population (percent change)',
+    isChange: true,
     isPercent: true,
     stops: ['#ffc0b4',-5,'#ffffff', 5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476', 50,'#012661']
   },
@@ -351,6 +357,7 @@ const choroplethConfigs = [
     tooltip: 'Percent change in the White Non-Hispanic population, 2010 to 2020',
     legendTitle: 'White Non-Hispanic (percent change)',
     isPercent: true,
+    isChange: true,
     insignificantLegendLabel: 'Less than 5,000 White Non-Hispanic in 2020',
     stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
   },
@@ -360,6 +367,7 @@ const choroplethConfigs = [
     label: 'Black Non-Hispanic (percent change)',
     tooltip: 'Percent change in the Black Non-Hispanic population, 2010 to 2020',
     legendTitle: 'Black Non-Hispanic (percent change)',
+    isChange: true,
     isPercent: true,
     insignificantLegendLabel: 'Less than 5,000 Black Non-Hispanic in 2020',
     stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476']
@@ -370,6 +378,7 @@ const choroplethConfigs = [
     label: 'Asian Non-Hispanic (percent change)',
     tooltip: 'Percent change in the Asian Non-Hispanic population, 2010 to 2020',
     legendTitle: 'Asian Non-Hispanic (percent change)',
+    isChange: true,
     isPercent: true,
     insignificantLegendLabel: 'Less than 5,000 Asian Non-Hispanic in 2020',
     stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
@@ -380,6 +389,7 @@ const choroplethConfigs = [
     label: 'Hispanic (percent change)',
     tooltip: 'Percent change in the Hispanic population, 2010 to 2020',
     legendTitle: 'Hispanic (percent change)',
+    isChange: true,
     isPercent: true,
     insignificantLegendLabel: 'Less than 5,000 Hispanic in 2020',
     stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
@@ -438,6 +448,7 @@ const builtConfigs = choroplethConfigs.map((config) => {
     label,
     legendTitle,
     isPercent,
+    isChange,
     stops,
     tooltip,
     insignificantLegendLabel = false,
@@ -450,6 +461,7 @@ const builtConfigs = choroplethConfigs.map((config) => {
     legendTitle,
     tooltip,
     isPercent,
+    isChange,
     insignificantLegendLabel,
     colors: stops.filter(stop => typeof stop === 'string'),
     stops,

--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -335,56 +335,112 @@ const choroplethConfigs = [
     stops: ['#c81d00',-5000,'#f46c59',-1000,'#ffc0b4',-500,'#ffffff',500,'#b5d5e5',1000,'#0473ad',5000,'#0b5476'],
   },
   // Percent Change
-  // {
-  //   group: 'Census',
-  //   id: 'popu18_1_pc',
-  //   label: 'Population (percent change)',
-  //   tooltip: 'Percent change in population, 2010 to 2020',
-  //   legendTitle: 'Population (percent change)',
-  //   isPercent: true,
-  //   stops: ['#ffc0b4',-5,'#ffffff', 5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476', 50,'#012661']
-  // },
-  // {
-  //   group: 'Census',
-  //   id: 'wnh_pc',
-  //   label: 'White Non-Hispanic (percent change)',
-  //   tooltip: 'Percent change in the White Non-Hispanic population, 2010 to 2020',
-  //   legendTitle: 'White Non-Hispanic (percent change)',
-  //   isPercent: true,
-  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
-  // },
-  // {
-  //   group: 'Census',
-  //   id: 'bnh_pc',
-  //   label: 'Black Non-Hispanic (percent change)',
-  //   tooltip: 'Percent change in the Black Non-Hispanic population, 2010 to 2020',
-  //   legendTitle: 'Black Non-Hispanic (percent change)',
-  //   isPercent: true,
-  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476']
-  // },
-  // {
-  //   group: 'Census',
-  //   id: 'anh_pc',
-  //   label: 'Asian Non-Hispanic (percent change)',
-  //   tooltip: 'Percent change in the Asian Non-Hispanic population, 2010 to 2020',
-  //   legendTitle: 'Asian Non-Hispanic (percent change)',
-  //   isPercent: true,
-  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
-  // },
-  // {
-  //   group: 'Census',
-  //   id: 'hsp1_pc',
-  //   label: 'Hispanic (percent change)',
-  //   tooltip: 'Percent change in the Hispanic population, 2010 to 2020',
-  //   legendTitle: 'Hispanic (percent change)',
-  //   isPercent: true,
-  //   stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
-  // },
+  {
+    group: 'Census',
+    id: 'popu18_1_pc',
+    label: 'Population (percent change)',
+    tooltip: 'Percent change in population, 2010 to 2020',
+    legendTitle: 'Population (percent change)',
+    isPercent: true,
+    stops: ['#ffc0b4',-5,'#ffffff', 5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476', 50,'#012661']
+  },
+  {
+    group: 'Census',
+    id: 'wnh_pc',
+    label: 'White Non-Hispanic (percent change)',
+    tooltip: 'Percent change in the White Non-Hispanic population, 2010 to 2020',
+    legendTitle: 'White Non-Hispanic (percent change)',
+    isPercent: true,
+    insignificantLegendLabel: 'Less than 5,000 White Non-Hispanic in 2020',
+    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
+  },
+  {
+    group: 'Census',
+    id: 'bnh_pc',
+    label: 'Black Non-Hispanic (percent change)',
+    tooltip: 'Percent change in the Black Non-Hispanic population, 2010 to 2020',
+    legendTitle: 'Black Non-Hispanic (percent change)',
+    isPercent: true,
+    insignificantLegendLabel: 'Less than 5,000 Black Non-Hispanic in 2020',
+    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476']
+  },
+  {
+    group: 'Census',
+    id: 'anh_pc',
+    label: 'Asian Non-Hispanic (percent change)',
+    tooltip: 'Percent change in the Asian Non-Hispanic population, 2010 to 2020',
+    legendTitle: 'Asian Non-Hispanic (percent change)',
+    isPercent: true,
+    insignificantLegendLabel: 'Less than 5,000 Asian Non-Hispanic in 2020',
+    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
+  },
+  {
+    group: 'Census',
+    id: 'hsp1_pc',
+    label: 'Hispanic (percent change)',
+    tooltip: 'Percent change in the Hispanic population, 2010 to 2020',
+    legendTitle: 'Hispanic (percent change)',
+    isPercent: true,
+    insignificantLegendLabel: 'Less than 5,000 Hispanic in 2020',
+    stops: ['#c81d00', -15, '#f46c59',-10,'#ffc0b4',-5,'#ffffff',5,'#b5d5e5',10,'#5fa4cb',15,'#0473ad',25,'#0b5476',50,'#012661']
+  },
 ];
+
+// Constant under which the racial group percent change variables should be considered insignificant
+const MINIMUM_RACIAL_COUNT = 5000;
+
+// The logic for NTA fill color is different for racial group percent change variables.
+// When the corresponding population count for those values is below a certain minimum
+// (5000 in our case), the NTA will show as a light grey when the percent change is selected
+// For all other variables, or for racial group percent change when the count is above the minimum,
+// fill color is simply determined by the "steps" array
+const buildPaintFill = (id, minimum, stops) => {
+  const racialPercentChangeIds = ['wnh_pc','bnh_pc','anh_pc','hsp1_pc']
+
+  return racialPercentChangeIds.includes(id)
+  ? {
+      'fill-color': [
+        "case",
+        ['<', ['get',id.split("_")[0]], minimum],
+        ["rgba", 220, 220, 220, 1],
+        [
+          "match",
+          ['typeof', ['get', id]],
+          "number",
+          [
+            'step',
+            ['get', id],
+            ...stops,
+          ],
+          ["rgba", 0, 0, 0, 0]
+        ],
+      ],
+    }
+  : {
+    'fill-color': [
+      "match",
+      ['typeof', ['get', id]],
+      "number",
+      [
+        'step',
+        ['get', id],
+        ...stops,
+      ],
+      ["rgba", 0, 0, 0, 0]
+    ],
+  }
+}
 
 const builtConfigs = choroplethConfigs.map((config) => {
   const {
-    group, id, label, legendTitle, isPercent, stops, tooltip,
+    group,
+    id,
+    label,
+    legendTitle,
+    isPercent,
+    stops,
+    tooltip,
+    insignificantLegendLabel = false,
   } = config;
 
   return {
@@ -394,21 +450,10 @@ const builtConfigs = choroplethConfigs.map((config) => {
     legendTitle,
     tooltip,
     isPercent,
+    insignificantLegendLabel,
     colors: stops.filter(stop => typeof stop === 'string'),
     stops,
-    paintFill: {
-      'fill-color': [
-        "match",
-        ['typeof', ['get', id]],
-        "number",
-        [
-          'step',
-          ['get', id],
-          ...stops,
-        ],
-        ["rgba", 0, 0, 0, 0]
-      ],
-    },
+    paintFill: buildPaintFill(id, MINIMUM_RACIAL_COUNT, stops),
     paintLine: {
       'line-color': '#994d4d',
     },

--- a/app/choropleth-config/index.js
+++ b/app/choropleth-config/index.js
@@ -409,23 +409,23 @@ const buildPaintFill = (id, minimum, stops) => {
 
   return racialPercentChangeIds.includes(id)
   ? {
-      'fill-color': [
+    'fill-color': [
+      "match",
+      ['typeof', ['get', id]],
+      "number",
+      [
         "case",
         ['<', ['get',id.split("_")[0]], minimum],
         ["rgba", 220, 220, 220, 1],
         [
-          "match",
-          ['typeof', ['get', id]],
-          "number",
-          [
-            'step',
-            ['get', id],
-            ...stops,
-          ],
-          ["rgba", 0, 0, 0, 0]
+          'step',
+          ['get', id],
+          ...stops,
         ],
       ],
-    }
+      ["rgba", 0, 0, 0, 0]
+    ],
+  }
   : {
     'fill-color': [
       "match",

--- a/app/components/map-toolbar.js
+++ b/app/components/map-toolbar.js
@@ -56,19 +56,28 @@ export default Component.extend({
 
     // return an array of objects, each with a display-ready range and color
     const config = choroplethConfigs.find(d => d.id === mode);
-    const { isPercent, stops: _stops, colors } = config;
+    const { isPercent, isChange, stops: _stops, colors } = config;
     const stops = _stops.filter(stop => typeof stop === 'number')
 
     const format = (value) => { // eslint-disable-line
       return isPercent ? `${value}%` : numeral(value).format('0,0');
     };
 
+    const buildBottomLabel = (stop) => {
+      if (isChange)  {
+        return `Loss of ${format(Math.abs(stop))} or more`
+      } else if (isPercent) {
+        return `Less than ${format(stop)}`
+      }
+      return `Under ${format(stop)}`
+    }
+
     const labels = []
     stops.forEach((stop, i) => {
       const isPositive = (stops[i] > 0) ? true : false
       if (i === 0) {
         labels.push({
-          label: isPercent ? `Less than ${format(stop)}` : `Under ${format(stop)}`,
+          label: buildBottomLabel(stop),
           color: colors[0],
         })
       } else {

--- a/app/components/map-toolbar.js
+++ b/app/components/map-toolbar.js
@@ -44,7 +44,7 @@ export default Component.extend({
   }),
 
   insignificantLegendLabel: computed('choroplethMode', function() {
-    const { choroplethMode: mode } = this.getProperties('choroplethMode');
+    const mode = this.get('choroplethMode');
     const config = choroplethConfigs.find(d => d.id === mode);
     return (config && typeof config.insignificantLegendLabel !== 'undefined')
       ? config.insignificantLegendLabel

--- a/app/components/map-toolbar.js
+++ b/app/components/map-toolbar.js
@@ -43,6 +43,14 @@ export default Component.extend({
     return choroplethConfigs.find(d => d.id === mode).legendTitle;
   }),
 
+  insignificantLegendLabel: computed('choroplethMode', function() {
+    const { choroplethMode: mode } = this.getProperties('choroplethMode');
+    const config = choroplethConfigs.find(d => d.id === mode);
+    return (config && typeof config.insignificantLegendLabel !== 'undefined')
+      ? config.insignificantLegendLabel
+      : false
+  }),
+
   stops: computed('choroplethMode', function() {
     const { choroplethMode: mode } = this.getProperties('choroplethMode');
 

--- a/app/templates/components/map-toolbar.hbs
+++ b/app/templates/components/map-toolbar.hbs
@@ -120,6 +120,12 @@
               {{stop.label}}
             </div>
           {{/each}}
+          {{#if this.insignificantLegendLabel}}
+            <div class="legend-item">
+              <span class="legend-color" style={{sanitize-style (hash color='#dcdcdc')}}>{{fa-icon transform="grow-6" icon='square'}}</span>
+              {{this.insignificantLegendLabel}}
+            </div>
+          {{/if}}
         </div>
         <ul class="thematic-map-options">
           {{#each-in (group-by "group" this.choroplethConfigs) as |group configs|}}


### PR DESCRIPTION
### Summary
This PR adds back the choropleths (thematic maps) for percent change and adds the necessary logic to show a light grey color for ntas for percent change of racial populations when the total count of the corresponding racial group was below 5000 in 2020.

#### Tasks/Bug Numbers
 - Fixes [AB#5382](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5382)

