### PR TITLE
5297 - Resize default map zoom

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -64,8 +64,8 @@ export default Controller.extend({
   subduedNtaLabels,
   choroplethsSource,
 
-  zoom: 12.25,
-  center: [-73.9868, 40.724],
+  zoom: 9.7,
+  center: [-73.9868, 40.665],
   mode: 'direct-select',
 
   isDrawing: false,


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Resizes the default state of the map to display all of NYC.

#### Tasks/Bug Numbers
 - Fixes AB[#5297](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20O?workitem=5297)
<!---
Provide a link to a ticket, if applicable
-->
<img width="1440" alt="Screen Shot 2022-07-11 at 10 48 39 AM" src="https://user-images.githubusercontent.com/43344288/178318906-b50b32d7-51bb-4036-ae3b-d6d872a9ef19.png">

