### PR TITLE
5445 Add significance arrows for ACS differences

### DIFF
--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -46,6 +46,21 @@
       (format-number
           this.data.differenceSum
           precision=this.rowConfig.decimal)}}
+    {{#if (and
+      (lte @this.data.differenceMarginOfError (abs @this.data.differenceSum))
+      (not (or
+        (eq @this.data.sum 0)
+        (eq @this.dataComparison.sum 0)
+      ))
+    )}}
+      {{#if (gt @this.data.differenceSum 0)}}
+        {{fa-icon icon="arrow-up" class="green"}}
+      {{else if (lt @this.data.differenceSum 0)}}
+        {{fa-icon icon="arrow-down" class="red"}}
+      {{else}}
+        {{fa-icon icon=""}}
+      {{/if}}
+    {{/if}}
   </td>
   {{#if this.reliability}}
     <td class="
@@ -66,6 +81,21 @@
           (format-number
             this.data.differencePercent
             precision=1)}}
+      {{#if (and
+        (lte @this.data.differencePercentMarginOfError (abs @this.data.differencePercent))
+        (not (or
+          (eq @this.data.sum 0)
+          (eq @this.dataComparison.sum 0)
+        ))
+      )}}
+        {{#if (gt @this.data.differencePercent 0)}}
+          {{fa-icon icon="arrow-up" class="green"}}
+        {{else if (lt @this.data.differencePercent 0)}}
+          {{fa-icon icon="arrow-down" class="red"}}
+        {{else}}
+          {{fa-icon icon=""}}
+        {{/if}}
+      {{/if}}
     </td>
     {{#if this.reliability}}
       <td

--- a/app/templates/components/data-table-row-previous.hbs
+++ b/app/templates/components/data-table-row-previous.hbs
@@ -46,6 +46,21 @@
       (format-number
           this.data.previous.differenceSum
           precision=this.rowConfig.decimal)}}
+    {{#if (and
+      (lte @this.data.previous.differenceMarginOfError (abs @this.data.previous.differenceSum))
+      (not (or
+        (eq @this.data.previous.sum 0)
+        (eq @this.data.previousComparison.sum 0)
+      ))
+    )}}
+      {{#if (gt @this.data.previous.differenceSum 0)}}
+        {{fa-icon icon="arrow-up" class="green"}}
+      {{else if (lt @this.data.previous.differenceSum 0)}}
+        {{fa-icon icon="arrow-down" class="red"}}
+      {{else}}
+        {{fa-icon icon=""}}
+      {{/if}}
+    {{/if}}
   </td>
   {{#if this.reliability}}
     <td class="
@@ -67,6 +82,21 @@
           (format-number
             this.data.previous.differencePercent
             precision=1)}}
+      {{#if (and
+        (lte @this.data.previous.differencePercentMarginOfError (abs @this.data.previous.differencePercent))
+        (not (or
+          (eq @this.data.previous.sum 0)
+          (eq @this.data.previousComparison.sum 0)
+        ))
+      )}}
+        {{#if (gt @this.data.previous.differencePercent 0)}}
+          {{fa-icon icon="arrow-up" class="green"}}
+        {{else if (lt @this.data.previous.differencePercent 0)}}
+          {{fa-icon icon="arrow-down" class="red"}}
+        {{else}}
+          {{fa-icon icon=""}}
+        {{/if}}
+      {{/if}}
     </td>
     {{#if this.reliability}}
       <td


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
In the ACS data tables, add significance arrows in the Differences column that shows the relation between Selected Area (NYC) and Comparison geography using the same logic (green up arrow for increase, red down arrow for decrease as shown in the Change Over Time tables.


#### Tasks/Bug Numbers
 - Implements AB#5445


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
