### PR TITLE
5297 - Change default zoom

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -64,8 +64,8 @@ export default Controller.extend({
   subduedNtaLabels,
   choroplethsSource,
 
-  zoom: 12.25,
-  center: [-73.9868, 40.724],
+  zoom: 11.67,
+  center: [-73.9515, 40.7198],
   mode: 'direct-select',
 
   isDrawing: false,


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Resizes and repositions the default map view to include more of NYC.
<img width="1347" alt="Screen Shot 2022-07-14 at 9 27 59 AM" src="https://user-images.githubusercontent.com/43344288/179003478-1cf19fd7-7499-4c9e-be6f-2f1d43997d55.png">


#### Tasks/Bug Numbers
 - Fixes AB[#5297](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20O?workitem=5297)