### PR TITLE
9900 – Pre-release ACS data modal 

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import mapboxgl from 'mapbox-gl';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 
@@ -283,4 +284,11 @@ export default Controller.extend({
       customVisualOverlayPoints: false,
     })
   },
+  
+  @tracked openModal: true,
+
+  @action toggleModal() {
+    this.openModal = !this.openModal
+  }
 });
+

--- a/app/styles/modules/_m-reveal-modal.scss
+++ b/app/styles/modules/_m-reveal-modal.scss
@@ -6,11 +6,20 @@
   z-index: 3;
 }
 
-@include breakpoint(1280px up) {
-  #reveal-modal-container {
+@include breakpoint(1280px down) {
+  .desktop-header,
+  .desktop-body {
     display: none;
   }
 }
+
+@include breakpoint(1280px up) {
+  .mobile-header,
+  .mobile-body {
+    display: none;
+  }
+}
+
 
 .reveal-overlay {
   padding: 1rem;

--- a/app/styles/modules/_m-reveal-modal.scss
+++ b/app/styles/modules/_m-reveal-modal.scss
@@ -6,13 +6,6 @@
   z-index: 3;
 }
 
-@include breakpoint(1280px down) {
-  .desktop-header,
-  .desktop-body {
-    display: none;
-  }
-}
-
 @include breakpoint(1280px up) {
   .mobile-header,
   .mobile-body {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -46,5 +46,5 @@
     Uncomment the following component to enable the modal
     Change its content in ./components/default-modal.hbs
   --}}
-  {{default-modal}}
+  {{!-- {{default-modal}} --}}
 </div>

--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,17 +1,17 @@
 <RevealModal @open={{this.openModal}} @closeModal={{this.toggleModal}}>
+  <h1 class="header-large">
+    NYC Population FactFinder will be updated with the latest 2016-2020 American Community Survey (ACS) data in early August 2022.
+  </h1>
+
+  <p class="lead">
+    Current 2015-2019 ACS data will still be available via <a target="_blank" href="https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww1.nyc.gov%2Fsite%2Fplanning%2Fplanning-level%2Fnyc-population%2Famerican-community-survey.page&data=05%7C01%7CBMarchena%40planning.nyc.gov%7C89a5722e8d9548c963cb08da6f1286ab%7C32f56fc75f814e22a95b15da66513bef%7C0%7C0%7C637944422609862296%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Hvq%2BZ8A3%2FLOfLXxM%2BWk9YYOvbsW3Uom7pXkCmG1pPOA%3D&reserved=0">NYC City Planning's Population Division webpage</a>, along with older datasets.
+  </p>
+
   <h1 class="header-large mobile-header">
     NYC Population FactFinder is optimized for desktop screen widths. 
   </h1>
 
   <p class="lead mobile-body">
     Mobile support for NYC Population FactFinder will be added in the future. For the best experience, please use a browser with a minimum width of 1280px. 
-  </p>
-
-  <h1 class="header-large desktop-header">
-    NYC Population FactFinder will be updated with the latest 2016-2020 American Community Survey (ACS) data in early August 2022.
-  </h1>
-
-  <p class="lead desktop-body">
-    Current 2015-2019 ACS data will still be available via <a target="_blank" href="https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww1.nyc.gov%2Fsite%2Fplanning%2Fplanning-level%2Fnyc-population%2Famerican-community-survey.page&data=05%7C01%7CBMarchena%40planning.nyc.gov%7C89a5722e8d9548c963cb08da6f1286ab%7C32f56fc75f814e22a95b15da66513bef%7C0%7C0%7C637944422609862296%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Hvq%2BZ8A3%2FLOfLXxM%2BWk9YYOvbsW3Uom7pXkCmG1pPOA%3D&reserved=0">NYC City Planning's Population Division webpage</a>, along with older datasets.
   </p>
 </RevealModal>

--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,9 +1,17 @@
-<RevealModal @open={{this.open}} @closeModal={{action 'toggleModal'}}>
-  <h1 class="header-large">
+<RevealModal @open={{this.openModal}} @closeModal={{this.toggleModal}}>
+  <h1 class="header-large mobile-header">
     NYC Population FactFinder is optimized for desktop screen widths. 
   </h1>
 
-  <p class="lead">
+  <p class="lead mobile-body">
     Mobile support for NYC Population FactFinder will be added in the future. For the best experience, please use a browser with a minimum width of 1280px. 
+  </p>
+
+  <h1 class="header-large desktop-header">
+    NYC Population FactFinder will be updated with the latest 2016-2020 American Community Survey (ACS) data in early August 2022.
+  </h1>
+
+  <p class="lead desktop-body">
+    Current 2015-2019 ACS data will still be available via <a target="_blank" href="https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww1.nyc.gov%2Fsite%2Fplanning%2Fplanning-level%2Fnyc-population%2Famerican-community-survey.page&data=05%7C01%7CBMarchena%40planning.nyc.gov%7C89a5722e8d9548c963cb08da6f1286ab%7C32f56fc75f814e22a95b15da66513bef%7C0%7C0%7C637944422609862296%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Hvq%2BZ8A3%2FLOfLXxM%2BWk9YYOvbsW3Uom7pXkCmG1pPOA%3D&reserved=0">NYC City Planning's Population Division webpage</a>, along with older datasets.
   </p>
 </RevealModal>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -149,3 +149,5 @@
 </MapUtilityBox>
 
 {{outlet}}
+
+<DefaultModal @openModal={{this.openModal}} @toggleModal={{this.toggleModal}} />


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
This PR updates `default-modal` to display a message informing users of incoming ACS dataset changes. The modal conditionally renders either this message or the existing mobile warning depending on the user's device.

![Screen Shot 2022-07-26 at 2 53 47 PM](https://user-images.githubusercontent.com/43344288/181088699-6f45ad4b-4f6a-4d9f-9267-bf24bb8bb13f.png)

![Screen Shot 2022-07-27 at 9 54 49 AM](https://user-images.githubusercontent.com/43344288/181265357-57165ce3-6b92-4d13-8bba-5fea5855c0e1.png)


#### Tasks/Bug Numbers
 - Fixes AB[#9900](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/9900)