### PR TITLE
9908 hide all significance arrows on decennial pages/tables

### DIFF
--- a/app/templates/components/data-table-header-change.hbs
+++ b/app/templates/components/data-table-header-change.hbs
@@ -156,31 +156,37 @@
         <th class="text-right cell-border-bottom">
           <span>
             Number
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significant increase (green up-arrow), significant decrease (red down-arrow), no significant change (no arrow)'
-              side='left'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significant increase (green up-arrow), significant decrease (red down-arrow), no significant change (no arrow)'
+                side='left'
+              }}
+            {{/unless}}
           </span>
         </th>
         <th class="text-right cell-border-bottom">
           <span>
             Percent
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significant increase (green up-arrow), significant decrease (red down-arrow), no significant change (no arrow). 2020 number minus 2010 number, divided by 2010 number. Quotient multiplied by 100.'
-              side='bottom'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significant increase (green up-arrow), significant decrease (red down-arrow), no significant change (no arrow). 2020 number minus 2010 number, divided by 2010 number. Quotient multiplied by 100.'
+                side='bottom'
+              }}
+            {{/unless}}
           </span>
         </th>
         <th class="text-right cell-border-bottom">
           <span>
             Pctg. Pt.
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significant increase (green up-arrow), significant decrease (red down-arrow), no significant change (no arrow)'
-              side='left'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significant increase (green up-arrow), significant decrease (red down-arrow), no significant change (no arrow)'
+                side='left'
+              }}
+            {{/unless}}
           </span>
         </th>
       </tr>

--- a/app/templates/components/data-table-header-current.hbs
+++ b/app/templates/components/data-table-header-current.hbs
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th rowspan="{{if this.reliability "3" "2"}}">
-        {{#unless this.decennial}}
+        {{#unless @decennial}}
           <a {{action (mut this.reliability) (not this.reliability)}}>
             <span class="a11y-orange">
               {{#if this.reliability}}
@@ -45,21 +45,25 @@
       <th colspan="2" class="text-center cell-border-bottom">
         <span>
           Number
-          {{fa-icon icon='question-circle' transform='shrink-2'}}
-          {{ember-tooltip
-            text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-            side='left'
-          }}
+          {{#unless @decennial}}
+            {{fa-icon icon='question-circle' transform='shrink-2'}}
+            {{ember-tooltip
+              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+              side='left'
+            }}
+          {{/unless}}
         </span>
       </th>
       <th colspan="2" class="text-center cell-border-bottom">
         <span>
           Pctg. Pt.
-          {{fa-icon icon='question-circle' transform='shrink-2'}}
-          {{ember-tooltip
-            text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-            side='left'
-          }}
+          {{#unless @decennial}}
+            {{fa-icon icon='question-circle' transform='shrink-2'}}
+            {{ember-tooltip
+              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+              side='left'
+            }}
+          {{/unless}}
         </span>
       </th>
     </tr>
@@ -162,21 +166,25 @@
         <th class="text-right cell-border-bottom">
           <span>
             Number
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-              side='left'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+                side='left'
+              }}
+            {{/unless}}
           </span>
         </th>
         <th class="text-right cell-border-bottom">
           <span>
             Pctg. Pt.
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-              side='left'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+                side='left'
+              }}
+            {{/unless}}
           </span>
         </th>
       </tr>

--- a/app/templates/components/data-table-header-previous.hbs
+++ b/app/templates/components/data-table-header-previous.hbs
@@ -45,21 +45,25 @@
       <th colspan="2" class="text-center cell-border-bottom">
         <span>
           Number
-          {{fa-icon icon='question-circle' transform='shrink-2'}}
-          {{ember-tooltip
-            text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-            side='left'
-          }}
+          {{#unless @decennial}}
+            {{fa-icon icon='question-circle' transform='shrink-2'}}
+            {{ember-tooltip
+              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+              side='left'
+            }}
+          {{/unless}}
         </span>
       </th>
       <th colspan="2" class="text-center cell-border-bottom">
         <span>
           Pctg. Pt.
-          {{fa-icon icon='question-circle' transform='shrink-2'}}
-          {{ember-tooltip
-            text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-            side='left'
-          }}
+          {{#unless @decennial}}
+            {{fa-icon icon='question-circle' transform='shrink-2'}}
+            {{ember-tooltip
+              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+              side='left'
+            }}
+          {{/unless}}
         </span>
       </th>
     </tr>
@@ -162,21 +166,25 @@
         <th class="text-right cell-border-bottom">
           <span>
             Number
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-              side='left'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+                side='left'
+              }}
+            {{/unless}}
           </span>
         </th>
         <th class="text-right cell-border-bottom">
           <span>
             Pctg. Pt.
-            {{fa-icon icon='question-circle' transform='shrink-2'}}
-            {{ember-tooltip
-              text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
-              side='left'
-            }}
+            {{#unless @decennial}}
+              {{fa-icon icon='question-circle' transform='shrink-2'}}
+              {{ember-tooltip
+                text='Significantly higher (green up-arrow), significantly lower (red down-arrow), no significant difference (no arrow)'
+                side='left'
+              }}
+            {{/unless}}
           </span>
         </th>
       </tr>


### PR DESCRIPTION
### Summary
Wrapped the significance tooltips in blocks to hide all on decennial pages/tables

#### Tasks/Bug Numbers
 - Fixes [AB#9908](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9908)

#### before:
<img width="526" alt="change-before" src="https://user-images.githubusercontent.com/11340947/181354742-fd2bc334-a3ba-43e7-a1d2-a87efee023c1.png">

#### after
<img width="571" alt="change-after" src="https://user-images.githubusercontent.com/11340947/181354856-a9dc6b8a-687b-4a98-93f8-b80fb37c8002.png">
<img width="635" alt="2020-after" src="https://user-images.githubusercontent.com/11340947/181354860-64ce370b-b066-44e6-ae9d-5382151d2456.png">


