### PR TITLE
5537 Add the population and housing facts to the map selection box

### DIFF
--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -27,6 +27,8 @@ export default Component.extend({
 
   summaryLevel: alias('selection.summaryLevel'),
 
+  selectionSummaryData: alias('selection.current.selectionSummary.totals'),
+
   choroplethPaintFill: computed('choroplethMode', function() {
     const { choroplethMode: mode } = this.getProperties('choroplethMode');
 

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -193,65 +193,67 @@ body {
     font-weight: 500;
     color: $charcoal;
   }
+}
 
-  .map-utility-box-body {
-    color: black;
-    padding: 1.5rem 2rem;
-    font-size: 0.875rem;
-    font-weight: 400;
-    height: 60px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 1rem;
+.map-utility-box-body {
+  color: black;
+  padding: 1.5rem 2rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1rem;
 
-    strong {
-      font-weight: 700;
-    }
-
-    .map-utility-box-data {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-evenly;
-      margin-top: 2em;
-
-      span {
-        padding: 0.75em;
-        background-color: #129DED;
-        border-radius: 50%;
-        color: white;
-        font-size: 1.25em;
-      }
-      .map-utility-box-data-text {
-        padding-top: 1em; //set the same as the span above
-      }
-    }
-  }
-
-  .map-utility-box-buttons {
-    padding: 0;
-    display: flex;
-    flex-wrap: nowrap;
-    flex-direction: row;
-    justify-content: flex-start;
-    height: 40px;
-    border-top: 1px solid #AAAFB5;
-    > :last-child {
-      flex-grow: 1;
-    }
-  }
-
-  .map-utility-box-body-null {
-    padding: 1.5rem 2rem;
-    font-size: rem-calc(14);
-    p {
-      line-height: 1;
-    }
-    > :last-child {
-      margin-bottom: 0;
-    }
+  strong {
+    font-weight: 700;
   }
 }
+
+.map-utility-box-data {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  span {
+    padding: 0.75em;
+    background-color: #129DED;
+    border-radius: 50%;
+    color: white;
+    font-size: 1.25em;
+  }
+  .map-utility-box-data-text {
+    padding-top: 1em; //set the same as the span above
+  }
+}
+
+.map-utility-box-buttons {
+  padding: 0;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  justify-content: flex-start;
+  height: 40px;
+  border-top: 1px solid #AAAFB5;
+  > :last-child {
+    flex-grow: 1;
+  }
+}
+
+.map-utility-box-body-null {
+  padding: 1.5rem 2rem;
+  font-size: rem-calc(14);
+  p {
+    line-height: 1;
+  }
+  > :last-child {
+    margin-bottom: 0;
+  }
+}
+
 #clear-selection {
   background-color: $off-white;
   color: $charcoal;

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -25,7 +25,7 @@
             {{fa-icon icon='user-friends'}}
           </span>
           <div class="map-utility-box-data-text">
-            <strong>123,456</strong><br />
+            <strong>{{format-number this.selectionSummaryData.pop1 precision=0}}</strong><br />
             Population
           </div>    
         </div>
@@ -34,7 +34,7 @@
             {{fa-icon icon='building'}}
           </span>
           <div class="map-utility-box-data-text">
-            <strong>123,456</strong><br />
+            <strong>{{format-number this.selectionSummaryData.hunits precision=0}}</strong><br />
             Housing Units
           </div>    
         </div>

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -19,6 +19,26 @@
         {{/if}}
         selected
       </div>
+      <div class="map-utility-box-data">
+        <div>
+          <span>
+            {{fa-icon icon='user-friends'}}
+          </span>
+          <div class="map-utility-box-data-text">
+            <strong>123,456</strong><br />
+            Population
+          </div>    
+        </div>
+          <div>
+          <span>
+            {{fa-icon icon='building'}}
+          </span>
+          <div class="map-utility-box-data-text">
+            <strong>123,456</strong><br />
+            Housing Units
+          </div>    
+        </div>
+      </div>
       <div class="map-utility-box-buttons">
         <button id="clear-selection" class="button--clear-selection button" type="button" {{action this.clearSelection}}>
           <span class="a11y-orange">

--- a/app/utils/fetch-selection-summary.js
+++ b/app/utils/fetch-selection-summary.js
@@ -1,0 +1,16 @@
+import Environment from '../config/environment';
+
+const { SupportServiceHost } = Environment;
+
+const SELECTION_SUMMARY_API_URL = (survey = 'decennial', summaryVars = 'pop1,hunits', geoid = '0') => `${SupportServiceHost}/summary/${survey}/${summaryVars}/${geoid}`;
+
+
+export default async function fetchSelectionSummary(survey, summaryVars, geoid) {
+  if(geoid.length) {
+    let selectionResponse = null;
+    selectionResponse = await fetch(SELECTION_SUMMARY_API_URL(survey, summaryVars, geoid));
+    selectionResponse = await selectionResponse.json();
+    return selectionResponse;
+  }
+  return null;
+}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Adds the summary totals to the map selection box.
<img width="357" alt="image" src="https://user-images.githubusercontent.com/61206501/181641512-cbe294aa-c7bd-4b99-a548-ab7ffaa2b978.png">


#### Tasks/Bug Numbers
 - Along with a corresponding [pr in labs-factfinder-api](https://github.com/NYCPlanning/labs-factfinder-api/pull/199), completes [AB#5537](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5537)

