### PR TITLE
9997 Preliminary restoration of  Decennial current (2020) and previous (2000) bar charts

### DIFF
--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -65,6 +65,7 @@ export default Component.extend(ResizeAware, {
     const data = this.get('data');
     const config = this.get('config');
     const isDecennial = this.get('survey') === 'census'
+    const mode = this.get('mode');
 
     const el = this.$();
     const elWidth = el.width();
@@ -77,7 +78,7 @@ export default Component.extend(ResizeAware, {
       .attr('width', width + margin.left + margin.right)
       .attr('height', height + margin.top + margin.bottom);
 
-    const rawData = mungeBarChartData(config, data);
+    const rawData = mungeBarChartData(config, data, mode);
     const y = scaleBand()
       .domain(rawData.map(d => get(d, 'group')))
       .range([0, height])

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -116,6 +116,7 @@
                     title=chart.chartLabel
                     config=chart.chartConfig
                     survey=this.source.type
+                    mode=this.source.mode
                     data=this.surveyData
                     height=204
                   }}
@@ -162,6 +163,7 @@
               {{#if (and
                 (or
                   (eq this.source.id 'acs-current')
+                  (eq this.source.id 'acs-previous')
                 )
                 subtopic.charts
                 this.showCharts
@@ -172,6 +174,7 @@
                       title=chart.chartLabel
                       config=chart.chartConfig
                       survey=this.source.type
+                      mode=this.source.mode
                       data=this.surveyData
                       height=204
                     }}

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -102,7 +102,7 @@
               }}
             </div>
 
-            {{#if (and
+            {{!-- {{#if (and
               (or
                 (eq this.source.id 'decennial-current')
                 (eq this.source.id 'decennial-previous')
@@ -121,7 +121,7 @@
                   }}
                 {{/each}}
               </div>
-            {{/if}}
+            {{/if}} --}}
           </div>
 
           <hr>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -61,6 +61,27 @@
       </p>
       
     {{/if}}
+    <div class="grid-container fluid">
+      <div class="grid-x align-left">
+        <div class="cell shrink">
+          <div class="switch tiny show-charts-switch">
+            <input
+              id="show-charts-switch"
+              type="checkbox"
+              checked={{this.showCharts}}
+              name="show-charts-switch"
+              class="switch-input"
+              {{on "click" (fn this.toggleBooleanControl 'showCharts')}}
+            />
+            <label class="switch-paddle" for="show-charts-switch">
+            </label>
+          </div>
+        </div>
+        <div class="cell shrink text-left">
+          Show Charts
+        </div>
+      </div>
+    </div>
     {{#if (eq this.source.type 'census')}}
       {{#each this.topics as |subtopic|}}
         {{#if (eq subtopic.selected "selected")}}

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -102,10 +102,9 @@
               }}
             </div>
 
-            {{!-- {{#if (and
+            {{#if (and
               (or
                 (eq this.source.id 'decennial-current')
-                (eq this.source.id 'decennial-previous')
               )
               subtopic.charts
               this.showCharts
@@ -122,7 +121,7 @@
                   }}
                 {{/each}}
               </div>
-            {{/if}} --}}
+            {{/if}}
           </div>
 
           <hr>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -105,6 +105,7 @@
             {{#if (and
               (or
                 (eq this.source.id 'decennial-current')
+                (eq this.source.id 'decennial-previous')
               )
               subtopic.charts
               this.showCharts

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -162,7 +162,6 @@
               {{#if (and
                 (or
                   (eq this.source.id 'acs-current')
-                  (eq this.source.id 'acs-previous')
                 )
                 subtopic.charts
                 this.showCharts

--- a/app/utils/munge-bar-chart-data.js
+++ b/app/utils/munge-bar-chart-data.js
@@ -1,13 +1,29 @@
 import { get } from '@ember/object';
 
-export default (config, d) => (config.map(({ property, label }) => ({
-  percent: get(d, `${property}.percent`),
-  sum: get(d, `${property}.sum`),
-  moe: get(d, `${property}.marginOfError`),
-  percentMarginOfError: get(d, `${property}.percentMarginOfError`),
-  comparisonPercent: get(d, `${property}.comparisonPercent`),
-  comparisonPercentMarginOfError: get(d, `${property}.comparisonPercentMarginOfError`),
-  group: label,
-  classValue: property,
-}))
-);
+export default (config, data, mode) => {
+  const isPrevious = mode === 'previous';
+
+  if (isPrevious) {
+    return config.map(({ property, label}) => ({
+      percent: get(data, `${property}.previous.percent`),
+      sum: get(data, `${property}.previous.sum`),
+      moe: get(data, `${property}.previous.marginOfError`),
+      percentMarginOfError: get(data, `${property}.previous.percentMarginOfError`),
+      comparisonPercent: get(data, `${property}.previousComparison.percent`),
+      comparisonPercentMarginOfError: get(data, `${property}.previousComparison.percentMarginOfError`),
+      group: label,
+      classValue: property,
+    }));
+  }
+
+  return config.map(({ property, label}) => ({
+    percent: get(data, `${property}.percent`),
+    sum: get(data, `${property}.sum`),
+    moe: get(data, `${property}.marginOfError`),
+    percentMarginOfError: get(data, `${property}.percentMarginOfError`),
+    comparisonPercent: get(data, `${property}.comparisonPercent`),
+    comparisonPercentMarginOfError: get(data, `${property}.comparisonPercentMarginOfError`),
+    group: label,
+    classValue: property,
+  }));
+};


### PR DESCRIPTION
### Summary
This is a first pass of restoring all Decennial bar charts. Previously 2020 bar charts appeared without issue, but 2010 bar charts yielded errors and comparison area percentage did not appear in the charts.

This PR depends on #1027 being merged first.  #1027  fixes previous year bar charts by modifying mungeBarChartData() to consider the current 'mode' (current or previous) of the Explorer. 

This PR simply re-enables both previous and current year charts. 

#### Tasks/Bug Numbers
 - Fixes [AB#9997](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9997) [AB#9967](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9967)
