### PR TITLE
5223 chart resizing to fix label spacing

### DIFF
--- a/app/components/acs-bar.js
+++ b/app/components/acs-bar.js
@@ -70,7 +70,10 @@ export default Component.extend(ResizeAware, {
     const el = this.$();
     const elWidth = el.width();
 
-    const height = this.get('height') - margin.top - margin.bottom;
+    const rawData = mungeBarChartData(config, data, mode);
+    const additionalHeight = (rawData.length > 7) ? (16 * (rawData.length - 7)) : 0;
+
+    const height = this.get('height') - margin.top - margin.bottom + additionalHeight;
     const width = elWidth - margin.left - margin.right;
     const textWidth = width * 0.35;
 
@@ -78,7 +81,6 @@ export default Component.extend(ResizeAware, {
       .attr('width', width + margin.left + margin.right)
       .attr('height', height + margin.top + margin.bottom);
 
-    const rawData = mungeBarChartData(config, data, mode);
     const y = scaleBand()
       .domain(rawData.map(d => get(d, 'group')))
       .range([0, height])

--- a/app/topics-config/acs.js
+++ b/app/topics-config/acs.js
@@ -171,7 +171,7 @@ export default [
         charts: [
           {
             chartConfig: acsSocialChartConfig.residence1YearAgo,
-            chartLabel: 'Percent Distribution of Population who Lived in a Different House 1 Year Ago"',
+            chartLabel: 'Percent Distribution of Population who Lived in a Different House 1 Year Ago',
           },
         ],
         children: [],


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
styling issue.. top category label is cut off and text is tighter than category bars 
![image](https://user-images.githubusercontent.com/61206501/182687817-dcd2db92-a976-49df-a50b-56b079db0e0c.png)
![image](https://user-images.githubusercontent.com/61206501/182687828-86d4a9f7-2cc8-4add-99f6-2748c903fd95.png)


seems the chart is just stretched longer in the current app: 
![image](https://user-images.githubusercontent.com/61206501/182687800-d08b86df-0747-4bcc-bed1-b7462b39bc66.png)

The fix:
<img width="481" alt="image" src="https://user-images.githubusercontent.com/61206501/182688433-7603e9fc-f5e8-45e3-af1a-828020c42d77.png">



#### Tasks/Bug Numbers
 - Fixes [AB#5223](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5223)


### Technical Explanation
When Y-axis has more than 7 items, I have added 16px to the height per item over 7.

