### PR TITLE
10029 restore previous charts for certain topics 

### DIFF
--- a/app/chart-config/acs/economic/index.js
+++ b/app/chart-config/acs/economic/index.js
@@ -2,10 +2,12 @@ import classOfWorker from './class-of-worker';
 import incomeAndBenefits from './income-and-benefits';
 import commuteToWork from './commute-to-work';
 import occupation from './occupation';
+import ratioOfIncomeToPovertyLevel from './ratio-of-income-to-poverty-level';
 
 export default {
   classOfWorker,
   incomeAndBenefits,
   commuteToWork,
   occupation,
+  ratioOfIncomeToPovertyLevel
 };

--- a/app/chart-config/acs/economic/ratio-of-income-to-poverty-level.js
+++ b/app/chart-config/acs/economic/ratio-of-income-to-poverty-level.js
@@ -1,0 +1,50 @@
+export default [
+  {
+    property: 'pvu50',
+    label: 'Under .50',
+  },
+  {
+    property: 'pv50t74',
+    label: '.50 to .74',
+  },
+  {
+    property: 'pv75t99',
+    label: '.75 to .99',
+  },
+  {
+    property: 'pv100t124',
+    label: '1.00 to 1.24',
+  },
+  {
+    property: 'pv125t149',
+    label: '1.25 to 1.49',
+  },
+  {
+    property: 'pv150t174',
+    label: '1.50 to 1.74',
+  },
+  {
+    property: 'pv175t184',
+    label: '1.75 to 1.84',
+  },
+  {
+    property: 'pv185t199',
+    label: '1.85 to 1.99',
+  },
+  {
+    property: 'pv200t299',
+    label: '2.00 to 2.99',
+  },
+  {
+    property: 'pv300t399',
+    label: '3.00 to 3.99',
+  },
+  {
+    property: 'pv400t499',
+    label: '4.00 to 4.99',
+  },
+  {
+    property: 'pv500pl',
+    label: '5.00 and over',
+  },
+];

--- a/app/chart-config/acs/housing/gross-rent-grapi.js
+++ b/app/chart-config/acs/housing/gross-rent-grapi.js
@@ -1,0 +1,26 @@
+export default [
+  {
+    property: 'grpiu15',
+    label: 'Less than 15.0 percent',
+  },
+  {
+    property: 'grpi15t19',
+    label: '15.0 to 19.9 percent',
+  },
+  {
+    property: 'grpi20t24',
+    label: '20.0 to 24.9 percent',
+  },
+  {
+    property: 'grpi25t29',
+    label: '25.0 to 29.9 percent',
+  },
+  {
+    property: 'grpi30t34',
+    label: '30.0 to 34.9 percent',
+  },
+  {
+    property: 'grpi35pl',
+    label: '35.0 percent or more',
+  },
+];

--- a/app/chart-config/acs/housing/gross-rent-grapi.js
+++ b/app/chart-config/acs/housing/gross-rent-grapi.js
@@ -16,11 +16,11 @@ export default [
     label: '25.0 to 29.9 percent',
   },
   {
-    property: 'grpi30t34',
-    label: '30.0 to 34.9 percent',
+    property: 'grpi30pl',
+    label: '30.0 percent or more',
   },
   {
-    property: 'grpi35pl',
-    label: '35.0 percent or more',
+    property: 'grpi50pl',
+    label: '50.0 percent or more',
   },
 ];

--- a/app/chart-config/acs/housing/gross-rent.js
+++ b/app/chart-config/acs/housing/gross-rent.js
@@ -1,0 +1,30 @@
+export default [
+  {
+    property: 'gru500',
+    label: 'Less than $500',
+  },
+  {
+    property: 'gr500t999',
+    label: '$500 to $999',
+  },
+  {
+    property: 'gr1kt14k',
+    label: '$1,000 to $1499',
+  },
+  {
+    property: 'gr15kt19k',
+    label: '$1,500 to $1,999',
+  },
+  {
+    property: 'gr20kt24k',
+    label: '$2,000 to $2,499',
+  },
+  {
+    property: 'gr25kt29k',
+    label: '$2,500 to $2,999',
+  },
+  {
+    property: 'gr3kpl',
+    label: '$3,000 or more',
+  },
+];

--- a/app/chart-config/acs/housing/index.js
+++ b/app/chart-config/acs/housing/index.js
@@ -1,9 +1,13 @@
 import housingTenure from './housing-tenure';
 import value from './value';
 import vehiclesAvailable from './vehicles-available';
+import grossRent from './gross-rent';
+import grossRentGrapi from './gross-rent-grapi';
 
 export default {
   housingTenure,
   value,
   vehiclesAvailable,
+  grossRent,
+  grossRentGrapi
 };

--- a/app/topics-config/acs.js
+++ b/app/topics-config/acs.js
@@ -358,7 +358,12 @@ export default [
         tooltip: "Ratio of income in the past 12 months to poverty level",
         type: 'subtopic',
         tableConfig: acsEconomicTableConfig.ratioOfIncomeToPovertyLevel,
-        charts: [],
+        charts: [
+          {
+            chartConfig: acsEconomicChartConfig.ratioOfIncomeToPovertyLevel,
+            chartLabel: 'Percent Distribution of Population by Ratio of Income to Poverty Level'
+          }
+        ],
         children: [],
       },
     ],
@@ -491,7 +496,12 @@ export default [
         selected: 'unselected',
         type: 'subtopic',
         tableConfig: acsHousingTableConfig.grossRent,
-        charts: [],
+        charts: [
+          {
+            chartConfig: acsHousingChartConfig.grossRent,
+            chartLabel: 'Percent Distribution of Renter-occupied Households by Gross Rent (2016-2020 only)',
+          },
+        ],
         children: [],
       },
       {
@@ -500,7 +510,12 @@ export default [
         selected: 'unselected',
         type: 'subtopic',
         tableConfig: acsHousingTableConfig.grossRentAsAPercentageOfHouseholdIncomeGrapi,
-        charts: [],
+        charts: [
+          {
+            chartConfig: acsHousingChartConfig.grossRentGrapi,
+            chartLabel: 'Percent Distribution of Renter-occupied Households by Gross Rent as a Percentage of Household Income',
+          },
+        ],
         children: [],
       },
     ],


### PR DESCRIPTION
### Summary
We previously removed charts for certain topics according to a list charts required for the 2020 rework, but want to restore them now. 
This PR restores them and also updates them with 2020 schema changes.

#### Tasks/Bug Numbers
 - Fixes [AB#10029](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/10029)
