### PR TITLE
9971 restore 2020 pop pyramid chart

### DIFF
--- a/app/components/population-pyramid.js
+++ b/app/components/population-pyramid.js
@@ -64,7 +64,7 @@ export default HorizontalBar.extend({
     const data = this.get('data');
     const isPrevious = this.get('mode') === 'previous';
 
-    function getVariableValue(row, maleFemale, variable) {
+    function getByMode(row, maleFemale, variable) {
       const variableAsSuffix = variable[0].toUpperCase() + variable.slice(1,variable.length);
       const variableFullname = isPrevious ? 'previous' + variableAsSuffix : variable;
 
@@ -74,12 +74,12 @@ export default HorizontalBar.extend({
     // get the largest of largest (percent + percentMarginOfError)
     const maxValue = max([
       max([
-        max(data, row => getVariableValue(row, 'male', 'percent') + getVariableValue(row, 'male', 'percentMarginOfError')),
-        max(data, row => getVariableValue(row, 'female', 'percent') + getVariableValue(row, 'female', 'percentMarginOfError')),
+        max(data, row => getByMode(row, 'male', 'percent') + getByMode(row, 'male', 'percentMarginOfError')),
+        max(data, row => getByMode(row, 'female', 'percent') + getByMode(row, 'female', 'percentMarginOfError')),
       ]),
       max([
-        max(data, row => getVariableValue(row, 'male', 'comparisonPercent') + getVariableValue(row, 'male', 'comparisonPercentMarginOfError')),
-        max(data, row => getVariableValue(row, 'female', 'comparisonPercent') + getVariableValue(row, 'female', 'comparisonPercentMarginOfError')),
+        max(data, row => getByMode(row, 'male', 'comparisonPercent') + getByMode(row, 'male', 'comparisonPercentMarginOfError')),
+        max(data, row => getByMode(row, 'female', 'comparisonPercent') + getByMode(row, 'female', 'comparisonPercentMarginOfError')),
       ]),
     ]);
 
@@ -92,10 +92,10 @@ export default HorizontalBar.extend({
 
     // tooltip renderer
     const toolTip = (d, type) => {
-      const percent = getVariableValue(d, type, 'percent');
-      const percentM = getVariableValue(d, type, 'percentMarginOfError');
-      const estimate = getVariableValue(d, type, 'sum');
-      const moe = getVariableValue(d, type, 'marginOfError');
+      const percent = getByMode(d, type, 'percent');
+      const percentM = getByMode(d, type, 'percentMarginOfError');
+      const estimate = getByMode(d, type, 'sum');
+      const moe = getByMode(d, type, 'marginOfError');
 
       return `
         The ${type} population aged ${yAxisFormat(get(d, 'group'))}
@@ -240,14 +240,14 @@ export default HorizontalBar.extend({
 
     const handleMOEs = (selection, type) => {
       const xFunction = (d) => {
-        if (getVariableValue(d, type, 'percentMarginOfError') > getVariableValue(d, type, 'percent')) return 0;
-        return xScale(getVariableValue(d, type, 'percent')) - xScale(getVariableValue(d, type, 'percentMarginOfError'));
+        if (getByMode(d, type, 'percentMarginOfError') > getByMode(d, type, 'percent')) return 0;
+        return xScale(getByMode(d, type, 'percent')) - xScale(getByMode(d, type, 'percentMarginOfError'));
       };
 
       const widthFunction = (d) => {
-        const defaultWidth = xScale(getVariableValue(d, type, 'percentMarginOfError')) * 2;
-        if (getVariableValue(d, type, 'percentMarginOfError') > getVariableValue(d, type, 'percent')) {
-          const newWidth = (defaultWidth - (xScale(getVariableValue(d, type, 'percentMarginOfError') - getVariableValue(d, type, 'percent'))));
+        const defaultWidth = xScale(getByMode(d, type, 'percentMarginOfError')) * 2;
+        if (getByMode(d, type, 'percentMarginOfError') > getByMode(d, type, 'percent')) {
+          const newWidth = (defaultWidth - (xScale(getByMode(d, type, 'percentMarginOfError') - getByMode(d, type, 'percent'))));
           return newWidth;
         }
         return defaultWidth;
@@ -286,9 +286,9 @@ export default HorizontalBar.extend({
 
     const handleComparisonMOEs = (selection, type) => {
       const xFunction = (d) => { // eslint-disable-line
-        return xScale(getVariableValue(d, type, 'comparisonPercent')) - xScale(getVariableValue(d, type, 'comparisonPercentMarginOfError'));
+        return xScale(getByMode(d, type, 'comparisonPercent')) - xScale(getByMode(d, type, 'comparisonPercentMarginOfError'));
       };
-      const widthFunction = d => xScale(getVariableValue(d, type, 'comparisonPercentMarginOfError')) * 2;
+      const widthFunction = d => xScale(getByMode(d, type, 'comparisonPercentMarginOfError')) * 2;
 
       selection.enter()
         .append('rect')
@@ -320,7 +320,7 @@ export default HorizontalBar.extend({
       .data(data, d => get(d, 'group'));
 
     const handleComparisons = (selection, type) => {
-      const cxFunction = d => xScale(getVariableValue(d, type, 'comparisonPercent'));
+      const cxFunction = d => xScale(getByMode(d, type, 'comparisonPercent'));
       selection.enter()
         .append('circle')
         .attr('class', d => `comparison ${type} ${get(d, 'group')}`)

--- a/app/components/population-pyramid.js
+++ b/app/components/population-pyramid.js
@@ -61,7 +61,7 @@ export default HorizontalBar.extend({
 
   updateChart() {
     const svg = this.get('svg');
-    const data = this.get('data.pyramidData');
+    const data = this.get('data');
 
     // get the largest of largest (percent + percentMarginOfError)
     const maxValue = max([

--- a/app/components/population-pyramid.js
+++ b/app/components/population-pyramid.js
@@ -62,16 +62,24 @@ export default HorizontalBar.extend({
   updateChart() {
     const svg = this.get('svg');
     const data = this.get('data');
+    const isPrevious = this.get('mode') === 'previous';
+
+    function getVariableValue(row, maleFemale, variable) {
+      const variableAsSuffix = variable[0].toUpperCase() + variable.slice(1,variable.length);
+      const variableFullname = isPrevious ? 'previous' + variableAsSuffix : variable;
+
+      return row[maleFemale][variableFullname];
+    }
 
     // get the largest of largest (percent + percentMarginOfError)
     const maxValue = max([
       max([
-        max(data, d => get(d, 'male.percent') + get(d, 'male.percentMarginOfError')),
-        max(data, d => get(d, 'female.percent') + get(d, 'female.percentMarginOfError')),
+        max(data, row => getVariableValue(row, 'male', 'percent') + getVariableValue(row, 'male', 'percentMarginOfError')),
+        max(data, row => getVariableValue(row, 'female', 'percent') + getVariableValue(row, 'female', 'percentMarginOfError')),
       ]),
       max([
-        max(data, d => get(d, 'male.comparisonPercent') + get(d, 'male.comparisonPercentMarginOfError')),
-        max(data, d => get(d, 'female.comparisonPercent') + get(d, 'female.comparisonPercentMarginOfError')),
+        max(data, row => getVariableValue(row, 'male', 'comparisonPercent') + getVariableValue(row, 'male', 'comparisonPercentMarginOfError')),
+        max(data, row => getVariableValue(row, 'female', 'comparisonPercent') + getVariableValue(row, 'female', 'comparisonPercentMarginOfError')),
       ]),
     ]);
 
@@ -84,10 +92,10 @@ export default HorizontalBar.extend({
 
     // tooltip renderer
     const toolTip = (d, type) => {
-      const percent = get(d, `${type}.percent`);
-      const percentM = get(d, `${type}.percentMarginOfError`);
-      const estimate = get(d, `${type}.sum`);
-      const moe = get(d, `${type}.marginOfError`);
+      const percent = getVariableValue(d, type, 'percent');
+      const percentM = getVariableValue(d, type, 'percentMarginOfError');
+      const estimate = getVariableValue(d, type, 'sum');
+      const moe = getVariableValue(d, type, 'marginOfError');
 
       return `
         The ${type} population aged ${yAxisFormat(get(d, 'group'))}
@@ -232,14 +240,14 @@ export default HorizontalBar.extend({
 
     const handleMOEs = (selection, type) => {
       const xFunction = (d) => {
-        if (get(d, `${type}.percentMarginOfError`) > get(d, `${type}.percent`)) return 0;
-        return xScale(get(d, `${type}.percent`)) - xScale(get(d, `${type}.percentMarginOfError`));
+        if (getVariableValue(d, type, 'percentMarginOfError') > getVariableValue(d, type, 'percent')) return 0;
+        return xScale(getVariableValue(d, type, 'percent')) - xScale(getVariableValue(d, type, 'percentMarginOfError'));
       };
 
       const widthFunction = (d) => {
-        const defaultWidth = xScale(get(d, `${type}.percentMarginOfError`)) * 2;
-        if (get(d, `${type}.percentMarginOfError`) > get(d, `${type}.percent`)) {
-          const newWidth = (defaultWidth - (xScale(get(d, `${type}.percentMarginOfError`) - get(d, `${type}.percent`))));
+        const defaultWidth = xScale(getVariableValue(d, type, 'percentMarginOfError')) * 2;
+        if (getVariableValue(d, type, 'percentMarginOfError') > getVariableValue(d, type, 'percent')) {
+          const newWidth = (defaultWidth - (xScale(getVariableValue(d, type, 'percentMarginOfError') - getVariableValue(d, type, 'percent'))));
           return newWidth;
         }
         return defaultWidth;
@@ -278,9 +286,9 @@ export default HorizontalBar.extend({
 
     const handleComparisonMOEs = (selection, type) => {
       const xFunction = (d) => { // eslint-disable-line
-        return xScale(get(d, `${type}.comparisonPercent`)) - xScale(get(d, `${type}.comparisonPercentMarginOfError`));
+        return xScale(getVariableValue(d, type, 'comparisonPercent')) - xScale(getVariableValue(d, type, 'comparisonPercentMarginOfError'));
       };
-      const widthFunction = d => xScale(get(d, `${type}.comparisonPercentMarginOfError`)) * 2;
+      const widthFunction = d => xScale(getVariableValue(d, type, 'comparisonPercentMarginOfError')) * 2;
 
       selection.enter()
         .append('rect')
@@ -312,7 +320,7 @@ export default HorizontalBar.extend({
       .data(data, d => get(d, 'group'));
 
     const handleComparisons = (selection, type) => {
-      const cxFunction = d => xScale(get(d, `${type}.comparisonPercent`));
+      const cxFunction = d => xScale(getVariableValue(d, type, 'comparisonPercent'));
       selection.enter()
         .append('circle')
         .attr('class', d => `comparison ${type} ${get(d, 'group')}`)

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -232,6 +232,44 @@ export default class ExplorerController extends Controller {
     ].filter(d => d.features.length > 0);
   }
 
+  get agePopDist() {
+    const { surveyData } = this;
+
+    const variables = [
+      'pop0t5',
+      'pop5t9',
+      'pop10t14',
+      'pop15t19',
+      'pop20t24',
+      'pop25t29',
+      'pop30t34',
+      'pop35t39',
+      'pop40t44',
+      'pop45t49',
+      'pop50t54',
+      'pop55t59',
+      'pop60t64',
+      'pop65t69',
+      'pop70t74',
+      'pop75t79',
+      'pop80t84',
+      'pop85pl',
+    ];
+
+    const pyramidData = variables.map((variable) => {
+      const male = surveyData[`m${variable}`];
+      const female = surveyData[`f${variable}`];
+
+      return {
+        group: variable,
+        male,
+        female,
+      };
+    });
+
+    return pyramidData;
+  }
+
   @action setSource(newSource) {
     this.source = newSource;
     window.dataLayer = window.dataLayer || [];

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -145,20 +145,26 @@
                   (eq this.source.id 'acs-current')
                   (eq this.source.id 'acs-previous')
                 )
-                subtopic.charts
                 this.showCharts
               )}}
                 <div class="cell large-4 xxlarge-3">
-                  {{#each subtopic.charts as |chart|}}
-                    {{acs-bar
-                      title=chart.chartLabel
-                      config=chart.chartConfig
-                      survey=this.source.type
-                      mode=this.source.mode
-                      data=this.surveyData
-                      height=204
+                  {{#if (eq subtopic.id 'demo-sexAndAge')}}
+                    {{population-pyramid
+                      title="Age/Sex Distribution"
+                      data=this.agePopDist
                     }}
-                  {{/each}}
+                  {{else}}
+                    {{#each subtopic.charts as |chart|}}
+                      {{acs-bar
+                        title=chart.chartLabel
+                        config=chart.chartConfig
+                        survey=this.source.type
+                        mode=this.source.mode
+                        data=this.surveyData
+                        height=204
+                      }}
+                    {{/each}}
+                  {{/if}}
                 </div>
               {{/if}}
             </div>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -152,6 +152,7 @@
                     {{population-pyramid
                       title="Age/Sex Distribution"
                       data=this.agePopDist
+                      mode=this.mode
                     }}
                   {{else}}
                     {{#each subtopic.charts as |chart|}}

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -147,26 +147,30 @@
                 )
                 this.showCharts
               )}}
-                <div class="cell large-4 xxlarge-3">
-                  {{#if (eq subtopic.id 'demo-sexAndAge')}}
+                {{#if (eq subtopic.id 'demo-sexAndAge')}}
+                  <div class="cell large-4 xxlarge-3">
                     {{population-pyramid
                       title="Age/Sex Distribution"
                       data=this.agePopDist
                       mode=this.mode
                     }}
-                  {{else}}
-                    {{#each subtopic.charts as |chart|}}
-                      {{acs-bar
-                        title=chart.chartLabel
-                        config=chart.chartConfig
-                        survey=this.source.type
-                        mode=this.source.mode
-                        data=this.surveyData
-                        height=204
-                      }}
-                    {{/each}}
+                  </div>
+                {{else}}
+                  {{#if subtopic.charts}}
+                    <div class="cell large-4 xxlarge-3">
+                      {{#each subtopic.charts as |chart|}}
+                        {{acs-bar
+                          title=chart.chartLabel
+                          config=chart.chartConfig
+                          survey=this.source.type
+                          mode=this.source.mode
+                          data=this.surveyData
+                          height=204
+                        }}
+                      {{/each}}
+                    </div>
                   {{/if}}
-                </div>
+                {{/if}}
               {{/if}}
             </div>
 


### PR DESCRIPTION
### Summary
Fixes [AB#9971](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9971) Restores the ACS Sex and Age population pyramid chart for current year, and also wires it up to previous year data.