### PR TITLE
9994 Display immediate UI feedback upon selecting "All Topics"

### DIFF
--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -35,10 +35,16 @@ export default class ExplorerController extends Controller {
 
   @tracked showReliability = false;
 
+  @tracked isLoading = false;
+
   // The comparison geography ID.
   // Must match ID of one option in comparisonGeoOptions.
   // Default "0" maps to NYC.
   @tracked compareTo = "0";
+
+  pauseToRerender(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
+  }
 
   toggleSourceInList(sourceId) {
     return sourcesDefault.map((source) => {
@@ -284,7 +290,10 @@ export default class ExplorerController extends Controller {
     });
   }
 
-  @action toggleTopic(topic) {
+  @action async toggleTopic(topic) {
+    this.isLoading = true;
+    await this.pauseToRerender(1);
+
     if (topic.type === 'subtopic') {
         if (this.topicsIdList.includes(topic.id)) {
           this.topics = this.topicsIdList.filter(topicId => topicId !== topic.id);
@@ -302,10 +311,18 @@ export default class ExplorerController extends Controller {
         this.topics = this.topicsIdList.concat(topicChildrenIds);
       }
     }
+
+    this.isLoading = false;
   }
 
-  @action toggleAllTopics() {
+  @action async toggleAllTopics() {
+    this.isLoading = true;
+    await this.pauseToRerender(1);
+
     this.topics = this.isAllTopicsSelected === "unselected" ? "all" : "none";
+
+    this.isLoading = false;
+
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({
       'event' : 'select_all_topics',

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -18,6 +18,14 @@
   />
 </Toolbar>
 
+{{#if this.isLoading}}
+  <div class="spinner">
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
+  </div>
+{{/if}}
+
 <div class="overflow-y-grid grid-padding-x">
   <div class="cell auto" id="explorer-wrapper">
     <br>
@@ -137,6 +145,7 @@
                   config=subtopic.tableConfig
                   isModelLoading=this.reloadExplorerModel.isRunning
                   model=this.surveyData
+                  selectionStatus=subtopic.selected
                 }}
               </div>
 

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -145,7 +145,6 @@
                   config=subtopic.tableConfig
                   isModelLoading=this.reloadExplorerModel.isRunning
                   model=this.surveyData
-                  selectionStatus=subtopic.selected
                 }}
               </div>
 


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
The amount of time it takes for the user to receive UI feedback after clicking "All Topics" in the Select Topics dropdown is unacceptably long.  

This task is to give some sort of immediate UI feedback, such as a "loading" spinner, when the user clicks "All Topics". 

Ideally the spinner is in the large whitespace where the tables will eventually render 
![image](https://user-images.githubusercontent.com/61206501/183743068-7ef57c2b-33de-463d-865a-200257bfca6a.png)



#### Tasks/Bug Numbers
 - Fixes [AB#9994](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9994)


### Technical Explanation
When a user changes which topics are selected, it does not fetch any data.  The delay is simply how long it takes Ember to re-render the DOM.  When it needs to render 42 tables, that amount of time creeps up into multiple seconds.  Ember's built-in loading screen is built on the premise that it is waiting for a network request to resolve, not that it will take a while to re-render the DOM.  This solution adds a variable to track the loading state, and makes the following changes to both functions that are triggered when a user changes one/all topics:
- At the beginning of the function, changes the isLoading to true, then;
- Adds a millisecond pause
- At the end of the function, changes the isLoading back to false

The millisecond pause is necessary to trigger the re-rendering to show the loading indicator; without it, it would not render the loading indicator until it has also rendered the tables, at which point the loading is complete.
