### PR TITLE
5537 Add source and tweak styles for map utility box quick facts

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -215,10 +215,10 @@ body {
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
-  margin-top: 2rem;
+  margin-top: 1rem;
   margin-bottom: 2rem;
 
-  span {
+  > div > span {
     padding: 0.75em;
     background-color: #129DED;
     border-radius: 50%;
@@ -226,7 +226,14 @@ body {
     font-size: 1.25em;
   }
   .map-utility-box-data-text {
-    padding-top: 1em; //set the same as the span above
+    font-size: 0.875rem;
+    padding-top: 1.25em; //set the same as the span above
+
+    > span {
+      font-size: 0.75rem;
+      font-style: italic;
+      color: $dark-gray;
+    }
   }
 }
 

--- a/app/templates/components/map-utility-box.hbs
+++ b/app/templates/components/map-utility-box.hbs
@@ -26,16 +26,18 @@
           </span>
           <div class="map-utility-box-data-text">
             <strong>{{format-number this.selectionSummaryData.pop1 precision=0}}</strong><br />
-            Population
+            Population<br />
+            <span>(2020 Census)</span>
           </div>    
         </div>
           <div>
           <span>
-            {{fa-icon icon='building'}}
+            {{fa-icon icon='building' class='fa-w-20'}}
           </span>
           <div class="map-utility-box-data-text">
             <strong>{{format-number this.selectionSummaryData.hunits precision=0}}</strong><br />
-            Housing Units
+            Housing Units<br />
+            <span>(2020 Census)</span>
           </div>    
         </div>
       </div>


### PR DESCRIPTION
### Summary
This is just a small follow-up PR to [PR 1025](https://github.com/NYCPlanning/labs-factfinder/pull/1025) to incorporate some feedback from Erica.
<img width="352" alt="image" src="https://user-images.githubusercontent.com/9055367/186510145-ee6b4b40-5acb-4bdf-860d-5013d6553827.png">
