### PR TITLE
5043 removed deprecated copy method and use clipboard api

### DIFF
--- a/app/components/data-table.js
+++ b/app/components/data-table.js
@@ -28,27 +28,22 @@ export default Component.extend({
   actions: {
     handleCopy() {
       const [el] = this.get('element').getElementsByClassName('wrapper-for-copy');
-      const { body } = document;
-      let range;
-      let sel;
-      if (document.createRange && window.getSelection) {
-        range = document.createRange();
-        sel = window.getSelection();
-        sel.removeAllRanges();
-        try {
-          range.selectNodeContents(el);
-          sel.addRange(range);
-        } catch (e) {
-          range.selectNode(el);
-          sel.addRange(range);
-        }
-      } else if (body.createTextRange) {
-        range = body.createTextRange();
-        range.moveToElementText(el);
-        range.select();
+
+      if (!navigator.clipboard) {
+        alert("Clipboard copy feature works best on Chrome or Safari browsers ");
+        return
       }
 
-      document.execCommand('copy');
+      navigator.permissions.query({name: 'clipboard-write'}).then((result) => {
+        try {
+          if (result.state === 'granted' || result.state === 'prompt') {
+            navigator.clipboard.writeText(el.innerText);
+          }
+
+        } catch (e) {
+          console.log('error in table copy ', e.name + '\n' + e.message);
+        }
+      });
 
       this.get('metrics').trackEvent('GoogleAnalytics', {
         eventCategory: 'Data',


### PR DESCRIPTION
### Summary
When copying and pasting the tables on PFF, the up and down arrows (svg elements) could not be copied correctly so an empty space  was substituted when pasted, which caused spreadsheets to interpret the input as a string rather than a number (or percent).

I replaced the deprecated `Document.execCommand()` with the Clipboard API. The API can be set to only copy text, avoiding the addition of empty spaces when copying PFF table data.

#### Tasks/Bug Numbers
 - Fixes [AB#5043](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5043)

### Technical Explanation
[Document/execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)
[Clipboard_API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)