### PR TITLE
11731 note added to data selection dropdown

### DIFF
--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -82,6 +82,12 @@
           {{/each}}
         {{/if}}
       {{/if}}
+
+       <p class="red text-small">
+          *ACS data are not available for Community Districts (CDs). Alternatively, users can select Community District Tabulation Areas – rough approximations of CDs – to access ACS data.*
+       </p>
+
     </div>
   {{/if}}
+
 </div>


### PR DESCRIPTION
### Summary
Note to data selection dropdown to prompt users to use CDTA's instead of CDs to access ACD data for CDs

#### Tasks/Bug Numbers
 - Fixes [AB#11731](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/11731)
 - 
#### BEFORE
<img width="476" alt="Screen Shot 2023-01-04 at 2 22 43 PM" src="https://user-images.githubusercontent.com/11340947/210633565-346b3576-817e-4c29-b2ba-390c13bfd6ae.png">

#### AFTER
<img width="628" alt="Screen Shot 2023-01-04 at 2 22 11 PM" src="https://user-images.githubusercontent.com/11340947/210633699-871ea200-d9f2-4427-a399-f1f9ab7118b2.png">
