### PR TITLE
11731 changed font color for add'l copy to black (from red)

### DIFF
--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -83,7 +83,7 @@
         {{/if}}
       {{/if}}
 
-       <p class="red text-small">
+       <p class="text-small">
           *ACS data are not available for Community Districts (CDs). Alternatively, users can select Community District Tabulation Areas – rough approximations of CDs – to access ACS data.*
        </p>
 


### PR DESCRIPTION
### Summary
updated task to remove red copy and change to black.
#### Tasks/Bug Numbers
 - Fixes [AB#11731](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/11731)
