### PR TITLE
12683 district acs data dropdown warning

### DIFF
--- a/app/components/explorer/source-select-dropdown.js
+++ b/app/components/explorer/source-select-dropdown.js
@@ -62,4 +62,8 @@ export default class SourceSelectDropdownComponent extends Component {
     }
     return true;
   }
-}
+
+  get showDistrictACSWarning() {
+      return this.args.geotype === 'districts';
+    }
+  }

--- a/app/styles/modules/components/explorer/source-select-dropdown.scss
+++ b/app/styles/modules/components/explorer/source-select-dropdown.scss
@@ -47,4 +47,8 @@
   .disabled {
     color: $light-gray;
   }
+
+  .district-acs-warning {
+    margin-top: 1rem;
+  }
 }

--- a/app/templates/components/explorer/source-select-dropdown.hbs
+++ b/app/templates/components/explorer/source-select-dropdown.hbs
@@ -82,11 +82,11 @@
           {{/each}}
         {{/if}}
       {{/if}}
-
-       <p class="text-small">
-          *ACS data are not available for Community Districts (CDs). Alternatively, users can select Community District Tabulation Areas – rough approximations of CDs – to access ACS data.*
-       </p>
-
+      {{#if this.showDistrictACSWarning}}
+        <p class="text-small district-acs-warning">
+            *ACS data are not available for Community Districts (CDs). Alternatively, users can select Community District Tabulation Areas – rough approximations of CDs – to access ACS data.*
+        </p>
+      {{/if}}
     </div>
   {{/if}}
 


### PR DESCRIPTION
### Summary
- Only show ACS data warning message when community districts are the source.
- Add spacing above said warning

#### Tasks/Bug Numbers
 - Fixes [AB#12683](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12683)
 - Parent Story [AB#12660](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12660)

### Technical Explanation
- Implement a method on the component which checks whether the district ACS data warning should be shown, depending on whether the current source is a data district.
- Add 1rem top margin to paragraph
