### PR TITLE
Change environment.js to use planninglabs.nyc staging domain for layers API

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -60,14 +60,14 @@ module.exports = function (environment) {
     cartoUsername: process.env.CARTO_USERNAME || 'planninglabs',
 
     'ember-mapbox-composer': {
-      host: 'https://labs-layers-api-staging.herokuapp.com',
+      host: 'https://layers-api-staging.planninglabs.nyc',
       namespace: 'v1',
     },
 
     'mapbox-gl': {
       accessToken: 'pk.eyJ1Ijoid21hdHRnYXJkbmVyIiwiYSI6Ii1icTRNT3MifQ.WnayxAOEoXX-jWsNmHUhyg',
       map: {
-        style: 'https://labs-layers-api-staging.herokuapp.com/v1/base/style.json',
+        style: 'https://layers-api-staging.planninglabs.nyc/v1/base/style.json',
       },
     },
 


### PR DESCRIPTION
### Summary
The herokuapp.com URL for staging layers API is blocked by some firewalls so I'm temporarily switching back to the planninglabs.nyc URL for the same Heroku app. This should only affect staging deployments for PFF.