### PR TITLE
13364 revered lottie loading animation on most loading screens

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -49,6 +49,7 @@ $topbar-padding: 0rem 1.25rem;
 @import 'modules/_m-reveal-modal';
 @import 'modules/m-layer-groups-menu';
 @import 'modules/_m-search';
+@import 'modules/_m-spinner';
 
 @import "ember-power-select";
 

--- a/app/styles/modules/_m-spinner.scss
+++ b/app/styles/modules/_m-spinner.scss
@@ -1,0 +1,49 @@
+// --------------------------------------------------
+// Module: Spinner
+// --------------------------------------------------
+
+.spinner {
+  position: fixed;
+  z-index: 9999;
+  top: 50vh;
+  left: 50vw;
+  height: 18px;
+  width: 70px;
+  text-align: center;
+}
+
+.spinner > div {
+  width: 18px;
+  height: 18px;
+  background-color: $medium-gray;
+
+  border-radius: 100%;
+  display: inline-block;
+  -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce1 {
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+
+.spinner .bounce2 {
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+
+@-webkit-keyframes sk-bouncedelay {
+  0%, 80%, 100% { -webkit-transform: scale(0) }
+  40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes sk-bouncedelay {
+  0%, 80%, 100% {
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  } 40% {
+    -webkit-transform: scale(1.0);
+    transform: scale(1.0);
+  }
+}

--- a/app/templates/components/acs-bar.hbs
+++ b/app/templates/components/acs-bar.hbs
@@ -2,7 +2,7 @@
 
 {{#if (is-pending this.data)}}
   <div class="spinner-wrapper loading">
-    <PageLoadAnimation />
+    <PageLoadSpinner />
   </div>
 {{/if}}
 

--- a/app/templates/components/data-table-header-current.hbs
+++ b/app/templates/components/data-table-header-current.hbs
@@ -25,7 +25,7 @@
         )}}
           {{this.compareToLabel}}
         {{else}}
-          <PageLoadAnimation />
+          <PageLoadSpinner />
         {{/if}}
       </th>
       <th colspan="{{if this.reliability "4" "2"}}" class="text-center cell-border-bottom">Difference</th>

--- a/app/templates/components/data-table-header-previous.hbs
+++ b/app/templates/components/data-table-header-previous.hbs
@@ -25,7 +25,7 @@
         )}}
           {{@compareToLabel}}
         {{else}}
-          <PageLoadAnimation />
+          <PageLoadSpinner />
         {{/if}}
       </th>
       <th colspan="{{if @reliability "4" "2"}}" class="text-center cell-border-bottom">Difference</th>

--- a/app/templates/components/horizontal-bar.hbs
+++ b/app/templates/components/horizontal-bar.hbs
@@ -1,6 +1,6 @@
 {{#if (is-pending this.data)}}
   <div class="spinner-wrapper loading">
-    <PageLoadAnimation />
+    <PageLoadSpinner />
   </div>
 {{/if}}
 {{yield}}

--- a/app/templates/components/page-load-spinner.hbs
+++ b/app/templates/components/page-load-spinner.hbs
@@ -1,0 +1,5 @@
+<div class="spinner">
+  <div class="bounce1"></div>
+  <div class="bounce2"></div>
+  <div class="bounce3"></div>
+</div>

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -19,7 +19,7 @@
 </Toolbar>
 
 {{#if this.isLoading}}
-  <PageLoadAnimation />
+  <PageLoadSpinner />
 {{/if}}
 
 <div class="overflow-y-grid grid-padding-x">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -17,7 +17,7 @@
  {{!--  TURN THIS OFF TO GET RID OF THE MAP  --}}
 <div class="map-container">
   {{#if this.selection.getEntireGeoTask.isRunning}}
-    <PageLoadAnimation />
+    <PageLoadSpinner />
   {{/if}}
   <LabsMap 
     @id="map"

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,1 +1,1 @@
-<PageLoadAnimation />
+<PageLoadSpinner />


### PR DESCRIPTION
### Summary
The lottie animation screen was causing issues in various places throughout PFF where loading times shorter than (approx) 2 seconds, making the screen appear to blink. Reverting back to the 3 dots loading screen restored expected "smoothness" when PFF is fetching new data.

#### Tasks/Bug Numbers
 - Fixes 
     - [AB#13364](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/13364)
 - Related 
    - [AB#12726](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/12726)
    - [PR where lottie animation was first implemented](https://github.com/NYCPlanning/labs-factfinder/pull/1079)
