### PR TITLE
Remove references to unused factfinder--pumas layer

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -52,7 +52,6 @@ export default Route.extend({
         { id: 'factfinder--boroughs', visible: false },
         { id: 'factfinder--cities', visible: false },
         { id: 'factfinder--ntas', visible: false },
-        { id: 'factfinder--pumas', visible: false },
         { id: 'factfinder--cdtas', visible: false },
 
         { id: 'subway', visible: false },

--- a/app/services/selection.js
+++ b/app/services/selection.js
@@ -156,8 +156,6 @@ export default Service.extend({
           return 'factfinder--boroughs';
         case 'cities':
           return 'factfinder--cities';
-        case 'pumas':
-          return 'factfinder--pumas';
         default:
           return null;
       }


### PR DESCRIPTION
### Summary
This PR removes references to the currently unused "factfinder--pumas" layer. Currently that layer uses the `dcp_pumas` table in Carto, which GIS wants to remove in favor of year-specific tables. Since we removed the ability to show PUMAs from PFF a while ago, this PR is just cleaning up after ourselves and removing the possibility that asking Layers API for a layer that's mapped to soon-to-be non-existant table breaks things.