### PR TITLE
Bugs/epic 13898

### DIFF
--- a/app/components/population-pyramid-decennial.js
+++ b/app/components/population-pyramid-decennial.js
@@ -196,7 +196,7 @@ export default HorizontalBar.extend({
       .data(data, d => get(d, 'group'));
 
     const handleBars = (selection, type) => {
-      const widthFunction = d => xScale(get(d, `${type}.percent`));
+      const widthFunction = d => xScale(getByMode(d, type, 'percent'));
 
       selection.enter()
         .append('rect')

--- a/app/components/population-pyramid.js
+++ b/app/components/population-pyramid.js
@@ -198,7 +198,7 @@ export default HorizontalBar.extend({
       .data(data, d => get(d, 'group'));
 
     const handleBars = (selection, type) => {
-      const widthFunction = d => xScale(get(d, `${type}.percent`));
+      const widthFunction = d => xScale(getByMode(d, type, 'percent'));
 
       selection.enter()
         .append('rect')

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -30,7 +30,7 @@
   {{!-- Estimate --}}
   {{#with (format-number (abs @data.changeSum) precision=@rowConfig.decimal) as |roundedChangeSum|}}
     {{#with (format-number (abs @data.changeMarginOfError) precision=@rowConfig.decimal) as |roundedChangeMarginOfError|}}
-      <td class="cell-border-left change-estimate {{unless @data.changeIsReliable 'insignificant'}}">
+      <td class="cell-border-left change-estimate {{unless (or @data.changeIsReliable this.decennial) 'insignificant'}}">
         {{#unless (or
           (eq @data.changeSum null)
           (eq @data.changeSum undefined)
@@ -81,7 +81,7 @@
   {{#with (format-number (mult (abs @data.changePercent) 100) precision=1) as |roundedChangePercentage|}}
     {{#with (format-number (mult (abs @data.changePercentMarginOfError) 100) precision=1) as |roundedChangePercentageMarginOfError|}}
 
-      <td class="{{unless @data.changePercentIsReliable 'insignificant'}} change-percent">
+      <td class="{{unless (or @data.changePercentIsReliable this.decennial) 'insignificant'}} change-percent">
         {{#unless (or
           @data.isSpecial
           (eq @data.changePercent null)

--- a/app/templates/components/data-table-row-current.hbs
+++ b/app/templates/components/data-table-row-current.hbs
@@ -38,9 +38,13 @@
   <td
     class="cell-border-left
     {{if
+      (and
       (or
         (not this.data.differenceIsReliable)
-        (and (eq this.data.sum 0) (eq this.data.comparisonSum 0)))
+          (and (eq this.data.sum 0) (eq this.data.comparisonSum 0))
+        )
+        (not this.decennial)
+      )
       'insignificant'}}">
     {{unless (eq this.data.differenceSum null)
       (format-number
@@ -83,7 +87,7 @@
     </td>
   {{/if}}
     <td
-      class="{{unless this.data.differencePercentIsReliable 'insignificant'}} difference-percent">
+      class="{{unless (or this.data.differencePercentIsReliable this.decennial) 'insignificant'}} difference-percent">
       {{unless (or @data.isSpecial (eq this.data.differencePercent null))
           (format-number
             this.data.differencePercent

--- a/app/templates/components/data-table-row-previous.hbs
+++ b/app/templates/components/data-table-row-previous.hbs
@@ -38,9 +38,13 @@
   <td
     class="cell-border-left
     {{if
-      (or
-        (not this.data.previous.differenceIsReliable)
-        (and (eq this.data.previous.sum 0) (eq this.data.previousComparison.sum 0)))
+      (and
+        (or
+          (not this.data.previous.differenceIsReliable)
+          (and (eq this.data.previous.sum 0) (eq this.data.previousComparison.sum 0))
+        )
+        (not this.decennial)
+      )
       'insignificant'}}">
     {{unless (eq this.data.previous.differenceSum null)
       (format-number
@@ -83,7 +87,7 @@
   {{/if}}
 
     <td
-      class="{{unless this.data.previous.differencePercentIsReliable 'insignificant'}} difference-percent">
+      class="{{unless (or this.data.previous.differencePercentIsReliable this.decennial) 'insignificant'}} difference-percent">
       {{unless (or @data.isSpecial (eq this.data.previous.differencePercent null))
           (format-number
             this.data.previous.differencePercent

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -39,6 +39,7 @@
           {{else}}
             {{#if (eq this.mode 'current')}}
               {{data-table-row-current
+                decennial=this.decennial
                 mode=this.mode
                 reliability=this.reliability
                 comparison=this.comparison
@@ -47,6 +48,7 @@
               }}
             {{else if (eq this.mode 'previous')}}
               {{data-table-row-previous
+                decennial=this.decennial
                 mode=this.mode
                 reliability=this.reliability
                 comparison=this.comparison

--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,6 +1,6 @@
 <RevealModal @open={{this.openModal}} @closeModal={{this.toggleModal}}>
   <h1 class="header-large">
-    NYC Population FactFinder has been updated with 2017-2021 American Community Survey (ACS) data.
+    NYC Population FactFinder has been updated with data from the newly released 2020 Census Demographic & Housing Characteristics (DHC) file.
   </h1>
 
   <p class="lead">

--- a/app/templates/components/population-pyramid-decennial.hbs
+++ b/app/templates/components/population-pyramid-decennial.hbs
@@ -8,10 +8,8 @@
   <g>
 
     <rect x="0" y="9" height="11" width="20" rx="2" ry="2" class="bar"></rect>
-    <rect alighnment-baseline="middle" x="15" y="11.5" height="6" width="10" class="moe"></rect>
     <text fill="#000" x="30" dy="18" style="text-anchor: start;">Selected Area percent</text>
 
-    <rect x="2.5" y="29.5" height="1" width="20" class="comparisonmoe"></rect>
     <circle cx="12.5" cy="30" r="2.5" class="comparison"></circle>
     <text fill="#000" x="30" dy="33" style="text-anchor: start;">Comparison Area percent</text>
 

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -115,18 +115,27 @@
               subtopic.charts
               this.showCharts
             )}}
-              <div class="cell large-4 xxlarge-3">
                 {{#each subtopic.charts as |chart|}}
-                  {{acs-bar
-                    title=chart.chartLabel
-                    config=chart.chartConfig
-                    survey=this.source.type
-                    mode=this.source.mode
-                    data=this.surveyData
-                    height=204
-                  }}
+                {{!-- HACK: literally prevent the rendering of 2010 census household type
+                because data are not available. If more charts are configured for years that
+                do not have data, then a generalized solution is needed --}}
+                  {{#unless (and 
+                    (eq chart.chartLabel "Percent Distribution of Household Types")
+                    (eq this.source.type "census")
+                    (eq this.source.mode "previous")
+                  )}}
+                    <div class="cell large-4 xxlarge-3">
+                        {{acs-bar
+                          title=chart.chartLabel
+                          config=chart.chartConfig
+                          survey=this.source.type
+                          mode=this.source.mode
+                          data=this.surveyData
+                          height=204
+                        }}
+                    </div>
+                  {{/unless}}
                 {{/each}}
-              </div>
             {{/if}}
           </div>
 


### PR DESCRIPTION
### Summary

Relates to [labs-factfinder-api PR 248](https://github.com/NYCPlanning/labs-factfinder-api/pull/248)

Change landing dialog to reflect inclusion of DHC data

Resolve bugs associated with DHC and CCD updates

1)  Decennial difference calculations marked as insignificant: 
    - The code does have logic that specifically allows time and spatial comparisons across census data to be marked as insignificant. 
    - However, Population requested on this iteration that decennial data never be marked as insignificant. Consequently, an additional check for the presence decennial census is used before placing the 'insignificant' styling.
2) Chart issues:
   - Remove MOEs from legend Age/Sex pyramids: Simply needed to remove that part of the svgs
   - Age/Sex Pyramid histogram had incorrect data when looking at previous data: A previous refactor to support previous data missed the updated to the histogram function.
   - Household Type chart should be hidden for previous year as there is no data: The application data is organized in such a way that a generalized solution of 'hide charts where data are not available' is difficult. For now, the code simple excludes that chart specifically. If more charts need to be excluded in the future, we should take the time to make a general solution.


#### Tasks/Bug Numbers
[AB#14578](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14578)

Front-end controlled bugs enumerated in [AB#13898](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13898)
