### PR TITLE
remove banner text for archive note

### DIFF
--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -3,11 +3,6 @@
     NYC Population FactFinder has been updated with data from the newly released 2020 Census Demographic & Housing Characteristics (DHC) file.
   </h1>
 
-  <p class="lead">
-    2016-2020 ACS data are still available under the Archive > Older Profiles sub-section of the ACS page on 
-    <a target="_blank" href="https://www.nyc.gov/site/planning/planning-level/nyc-population/american-community-survey.page">NYC City Planning’s Population Division</a> website.
-  </p>
-
   <h1 class="header-large mobile-header">
     NYC Population FactFinder is optimized for desktop screen widths. 
   </h1>


### PR DESCRIPTION
# Description
Remove from the banner the note about 2016-2020 data being available in the archive

## Tickets
[AB#14578](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14578)
