### PR TITLE
issue/16067 Update copy homepage pop-up

### DIFF
--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,13 +1,17 @@
 <RevealModal @open={{this.openModal}} @closeModal={{this.toggleModal}}>
-  <h1 class="header-large">
-    NYC Population FactFinder has been updated with data from the newly released 2020 Census Demographic & Housing Characteristics (DHC) file.
+  <h1 class='header-large'>
+    NYC Population FactFinder will soon be updated with 2018-2022 American
+    Community Survey (ACS) data and with Detailed Race/Ethnicity Responses from
+    the 2020 Census.
   </h1>
 
-  <h1 class="header-large mobile-header">
-    NYC Population FactFinder is optimized for desktop screen widths. 
+  <h1 class='header-large mobile-header'>
+    NYC Population FactFinder is optimized for desktop screen widths.
   </h1>
 
-  <p class="lead mobile-body">
-    Mobile support for NYC Population FactFinder will be added in the future. For the best experience, please use a browser with a minimum width of 1280px. 
+  <p class='lead mobile-body'>
+    Mobile support for NYC Population FactFinder will be added in the future.
+    For the best experience, please use a browser with a minimum width of
+    1280px.
   </p>
 </RevealModal>


### PR DESCRIPTION
#### Description
Update copy of initial pop-up on opening the PFF
<img width="784" alt="Screenshot 2024-02-06 at 3 03 41 PM" src="https://github.com/NYCPlanning/labs-factfinder/assets/11340947/b1cab37c-8762-4799-9a41-ebfd4931c1a8">



#### Tickets
Closes #1121 