### PR TITLE
1123/16067 PFF Updates: Copy Changes: modify post-update pop-up message

### DIFF
--- a/app/templates/components/default-modal.hbs
+++ b/app/templates/components/default-modal.hbs
@@ -1,8 +1,6 @@
 <RevealModal @open={{this.openModal}} @closeModal={{this.toggleModal}}>
   <h1 class='header-large'>
-    NYC Population FactFinder will soon be updated with 2018-2022 American
-    Community Survey (ACS) data and with Detailed Race/Ethnicity Responses from
-    the 2020 Census.
+    NYC Population FactFinder has been updated with 2018-2022 American Community Survey (ACS) data and with Detailed Race/Ethnicity Responses from the 2020 Census. 2017-2021 ACS data are still available in the ACS sub-section of <a target="_blank" href="https://www.nyc.gov/site/planning/planning-level/nyc-population/american-community-survey.page">NYC City Planning's Population Division</a> website.
   </h1>
 
   <h1 class='header-large mobile-header'>


### PR DESCRIPTION
### Ticket 
[Issue 16067](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/16067)
[Workflow branch strategy](https://github.com/NYCPlanning/labs-factfinder/issues/1134)
 - #### AFTER UPDATE IS FINISHED 
   - [ ] Change text of initial pop-up on opening the application to **"NYC Population FactFinder has been updated with 2018-2022 American Community Survey (ACS) data and with Detailed Race/Ethnicity Responses from the 2020 Census. 2017-2021 ACS data are still available in the ACS sub-section of [NYC City Planning’s Population Division](https://www.nyc.gov/site/planning/planning-level/nyc-population/american-community-survey.page) website."** 