### PR TITLE
289 Search results now include CDTAs

### DIFF
--- a/app/components/map-search.js
+++ b/app/components/map-search.js
@@ -184,6 +184,12 @@ export default Component.extend({
         this.fitBounds(result.feature, 3);
       }
 
+      if (result.type === 'cdta') {
+        selection.set('searchResultFeature', result.feature);
+        this.set('searchTerms', result.feature.properties.cdta2020);
+        this.fitBounds(result.feature, 3);
+      }
+
       if (result.type === 'address') {
         const center = result.coordinates;
         selection.set('currentAddress', center);

--- a/app/templates/components/map-search.hbs
+++ b/app/templates/components/map-search.hbs
@@ -24,6 +24,8 @@
         <h4 class="header-small">Neighborhoods</h4>
       {{else if (eq type 'district')}}
         <h4 class="header-small">Community Districts</h4>
+      {{else if (eq type 'cdta')}}
+        <h4 class="header-small">2020 Community District Tabulation Areas</h4>
       {{else}}
         <h4 class="header-small">Add Map Pin</h4>
       {{/if}}
@@ -37,6 +39,8 @@
         {{else if (eq type 'nta')}}
           <span class="icon polygon large"></span>
         {{else if (eq type 'district')}}
+          <span class="icon polygon large"></span>
+        {{else if (eq type 'cdta')}}
           <span class="icon polygon large"></span>
         {{else}}
           {{fa-icon icon="map-pin"}}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Fixes an issue where when searching for a CDTA, the search and map does not yield a result.

#### Tasks/Bug Numbers
 - Along with [Factfinder API #291](https://github.com/NYCPlanning/labs-factfinder-api/pull/291) completes [Factfinder API Issue #289](https://github.com/NYCPlanning/labs-factfinder-api/issues/289)

<img width="1683" alt="image" src="https://github.com/NYCPlanning/labs-factfinder/assets/61206501/cb676ed2-0a7c-4d99-9f34-806463f2c65d">
