### PR TITLE
Set all layer groups to inactive on component init

### DIFF
--- a/app/components/labs-ui/layer-group-toggle.js
+++ b/app/components/labs-ui/layer-group-toggle.js
@@ -8,6 +8,8 @@ export default Component.extend({
     this.get('didInit')(this);
 
     this.set('icon', []);
+
+    this.set('active', false);
   },
 
   metrics: service('metrics'),


### PR DESCRIPTION
Closes #1153.

Now when initializing or navigating back to the map, layer group toggles will reset to the default inactive state.