### PR TITLE
Click on remove link after invalid upload

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -273,6 +273,7 @@ export default Controller.extend({
         //     alert('Something went wrong with this Shapefile. Try to simplify the geometries.'); // eslint-disable-line
         //   });
       }).catch(() => {
+        file._removeLink.click();
         alert('Something went wrong with this Shapefile. Check that it is valid'); // eslint-disable-line
       });
     };


### PR DESCRIPTION
Closes #1155

Unfortunately, our [dropzone](https://www.npmjs.com/package/ember-cli-dropzonejs) element is still displaying non-zipped files as accepted on the frontend. This PR programmatically clicks on the remove link for an invalid file after closing the error modal.