### PR TITLE
1172 hide change over time for detailed race and ethnicity

### DIFF
--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -1,4 +1,8 @@
-{{#unless (or @rowConfig.divider this.noPriorData)}}
+{{#unless (or 
+  @rowConfig.divider 
+  this.noPriorData 
+  (eq @data.category 'detailed_race_and_ethnicity')
+)}}
   <td class='title-column' {{action 'showData'}}>
     <span>
       {{@rowConfig.title}}
@@ -194,7 +198,17 @@
     {{/with}}
   {{/with}}
 {{else}}
-  {{#if this.noPriorData}}
+  {{#if (eq @data.category 'detailed_race_and_ethnicity')}}
+    {{!-- disable change over time for subregions in detailed_race_and_ethnicity chart --}}
+    <td class='title-column' {{action 'showData' }}>
+      <span>
+        {{@rowConfig.title}}
+      </span>
+    </td>
+    <td class="cell-border-left no-compare-message">
+      Data for this row are not comparable or are unavailable
+    </td>
+  {{else if this.noPriorData}}
     {{!-- if 2006-2010 sum is null, just return empty cells --}}
     <td class='title-column' {{action 'showData'}}>
       <span>


### PR DESCRIPTION
### Summary
for decennial data, change over time shouldn't appear for any of the regional groups in detailed race and ethnicity chart
#### Tasks/Bug Numbers
 - Closes #1172 

<img width="851" alt="Screenshot 2024-04-16 at 3 10 30 PM" src="https://github.com/NYCPlanning/labs-factfinder/assets/11340947/fe07539b-5e49-456d-8578-e1329fa173d8">

 
 ##### Note
Some clarification from Pop on the requirements:

<img width="1030" alt="Screenshot 2024-04-16 at 12 05 09 PM" src="https://github.com/NYCPlanning/labs-factfinder/assets/11340947/33b30c3b-1171-4d05-af89-b6e3529d1ba3">
