### PR TITLE
1175 updated under 18 years data variable

### DIFF
--- a/app/table-config/acs/demographic/sex-and-age.js
+++ b/app/table-config/acs/demographic/sex-and-age.js
@@ -113,7 +113,7 @@ export default [
   {
     title: 'Under 18 years',
     classNames: '',
-    data: 'popu18',
+    data: 'popu181',
   },
   {
     title: '65 years and over',
@@ -125,7 +125,8 @@ export default [
   },
   {
     title: 'Median age (years)',
-    tooltip: 'Medians are calculated using linear interpolation, which may result in top-coded values',
+    tooltip:
+      'Medians are calculated using linear interpolation, which may result in top-coded values',
     classNames: '',
     data: 'mdage',
     special: true,


### PR DESCRIPTION
### Summary
Update variable for `Under 18 years`

#### Tasks/Bug Numbers
 - Closes #1175 

#### Before:
![Screenshot 2024-04-17 at 5 24 25 PM](https://github.com/NYCPlanning/labs-factfinder/assets/11340947/78206136-d546-4a25-82f4-ef8df81e1ff7)

#### After
![Screenshot 2024-04-17 at 5 24 08 PM](https://github.com/NYCPlanning/labs-factfinder/assets/11340947/1e8816f2-ebb9-4cba-affe-052ad269f0a4)
