### PR TITLE
Remove values from header rows in Detailed Race and Ethnicity Section

### DIFF
--- a/app/components/data-table-row-change.js
+++ b/app/components/data-table-row-change.js
@@ -36,7 +36,7 @@ export default Component.extend({
 
   noPriorData: computed('data.previous.sum', function() {
     const { 'data.previous': previous } = this.getProperties('data.previous');
-    if (previous && (typeof previous.sum === 'undefined' || previous.sum === null)) {
+    if ((previous && (typeof previous.sum === 'undefined' || previous.sum === null)) || typeof previous === 'undefined') {
       return true
     }
     return false

--- a/app/components/data-table-row-previous.js
+++ b/app/components/data-table-row-previous.js
@@ -46,7 +46,6 @@ export default Component.extend({
   },
 
   click() {
-    console.log('click - data table', this);
     this.set('isSelected', !this.isSelected);
   },
 });

--- a/app/components/data-table-row-previous.js
+++ b/app/components/data-table-row-previous.js
@@ -33,7 +33,7 @@ export default Component.extend({
 
   noPriorData: computed('data.previous.sum', function() {
     const { 'data.previous': previous } = this.getProperties('data.previous');
-    if (previous && (typeof previous.sum === 'undefined' || previous.sum === null)) {
+    if ((previous && (typeof previous.sum === 'undefined' || previous.sum === null)) || typeof previous === 'undefined') {
       return true
     }
     return false
@@ -46,6 +46,7 @@ export default Component.extend({
   },
 
   click() {
+    console.log('click - data table', this);
     this.set('isSelected', !this.isSelected);
   },
 });

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -208,7 +208,11 @@
     <td
       class="cell-border-left no-compare-message"
     >
+      {{#unless (not this.rowConfig.data)}}
       Data for this row are not comparable or are unavailable
+      {{else}}
+      &nbsp;
+      {{/unless}}
     </td>
   {{else}}
     <td>&nbsp;</td>

--- a/app/templates/components/data-table-row-previous.hbs
+++ b/app/templates/components/data-table-row-previous.hbs
@@ -139,7 +139,11 @@
     <td
       class="cell-border-left no-compare-message"
     >
+      {{#unless (not this.rowConfig.data)}}
       Data for this row are not comparable or are unavailable
+      {{else}}
+      &nbsp;
+      {{/unless}}
     </td>
   {{else}}
     <td>&nbsp;</td>


### PR DESCRIPTION
Closes #1173.

Removes row values from headers in previous and change over time datasets.

![Screen Shot 2024-04-18 at 3 27 58 PM](https://github.com/NYCPlanning/labs-factfinder/assets/43344288/c0260b7e-f563-404d-89e9-596a20cdb0a1)

![Screen Shot 2024-04-18 at 3 54 05 PM](https://github.com/NYCPlanning/labs-factfinder/assets/43344288/a7982309-cff2-47d1-8df4-ecf9fa924ba6)
