### PR TITLE
Display percent change over time estimate 

### DIFF
--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -87,7 +87,6 @@
 
       <td class="{{unless (or @data.changePercentIsReliable this.decennial) 'insignificant'}} change-percent">
         {{#unless (or
-          @data.isSpecial
           (eq @data.changePercent null)
           (eq @data.changePercent undefined)
         )}}


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/labs-factfinder/issues/1233

How to replicate: 

1. Select geographies 
2. Update Data Source to ACS Change Over Time
3. Select a topic that has mean and/or median values (e.g. Income and Benefits under Economic)

Should have values for Change, 2006-2010 to 2019-2023 > Percent > Estimate
<img width="1882" alt="image" src="https://github.com/user-attachments/assets/d1bd5457-86b1-42ee-8dc0-94b17fc7c371" />
