### PR TITLE
PFF 2026 Data Updates fixes 

### DIFF
--- a/app/components/data-table-column-group.js
+++ b/app/components/data-table-column-group.js
@@ -1,13 +1,80 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+const VARIABLE_EXCLUSIONS = [
+  'pop',
+  'pop_1',
+  'pop_2',
+  'pop_4',
+  'pop_5',
+  'pop_6',
+  'mdpop3',
+];
 
 export default Component.extend({
   tagName: '',
+
+  selection: service(),
+
   reliabilityMode: false,
   model: null,
+  rowConfig: null,
+
+  selectedGeoids: computed(
+    'selection.current.features.@each.properties.geoid',
+    function () {
+      const features = this.get('selection.current.features') || [];
+
+      return features.map((feature) => {
+        if (feature.get) {
+          return feature.get('properties.geoid');
+        }
+
+        return feature.properties.geoid;
+      });
+    }
+  ),
+
+  geoid: computed('selectedGeoids.[]', function () {
+    const selectedGeoids = this.get('selectedGeoids');
+
+    return selectedGeoids.length === 1
+      ? selectedGeoids[0]
+      : null;
+  }),
+
+  shouldApplyInsignificantClass: computed(
+    'model.isReliable',
+    'rowConfig.data',
+    'geoid',
+    function () {
+      const isReliable = this.get('model.isReliable');
+      const rowConfigData = this.get('rowConfig.data') || '';
+      const geoid = Number(this.get('geoid'));
+
+      const containsExcludedVariable =
+        VARIABLE_EXCLUSIONS.some((variable) =>
+          rowConfigData.includes(variable)
+        );
+
+      const isExcludedGeoid =
+        Number.isInteger(geoid) &&
+        geoid >= 0 &&
+        geoid <= 5;
+
+      const shouldSkipInsignificantClass =
+        isExcludedGeoid &&
+        containsExcludedVariable;
+
+      return !isReliable && !shouldSkipInsignificantClass;
+    }
+  ),
 
   actions: {
     logModel() {
       window.logModel = this.get('model');
+      window.geoid = this.get('geoid');
     },
   },
 });

--- a/app/table-config/acs/social/place-of-birth.js
+++ b/app/table-config/acs/social/place-of-birth.js
@@ -376,7 +376,7 @@ export default [
   },
   {
     indent: 2,
-    title: '“Burma (Myanmar)',
+    title: 'Burma (Myanmar)',
     data: 'burma',
   },
   {

--- a/app/templates/components/data-table-column-group.hbs
+++ b/app/templates/components/data-table-column-group.hbs
@@ -1,5 +1,8 @@
 {{!-- Estimate --}}
-<td class="cell-border-left {{unless this.model.isReliable 'insignificant'}}" {{action 'logModel'}}>
+<td class="cell-border-left
+  {{if this.shouldApplyInsignificantClass "insignificant"}}"
+  {{action 'logModel'}}
+>
   {{format-number
       this.model.sum
       precision=this.rowConfig.decimal}}{{render-top-bottom-coding-suffix this.model.direction}}

--- a/app/templates/components/data-table-row-change.hbs
+++ b/app/templates/components/data-table-row-change.hbs
@@ -1,6 +1,6 @@
-{{#unless (or 
-  @rowConfig.divider 
-  this.noPriorData 
+{{#unless (or
+  @rowConfig.divider
+  this.noPriorData
   (eq @data.category 'detailed_race_and_ethnicity')
 )}}
   <td class='title-column' {{action 'showData'}}>
@@ -143,7 +143,7 @@
       (mult (abs @data.changePercentagePointMarginOfError) 100)
       precision=1) as |roundedChangePercentagePointMarginOfError|}}
 
-      <td class="{{unless @data.changePercentagePointIsReliable 'insignificant'}} change-percentage-point">
+      <td class="{{unless (or @data.changePercentagePointIsReliable this.decennial) 'insignificant'}} change-percentage-point">
         {{#unless
           (or
             @data.isSpecial


### PR DESCRIPTION
### Summary
    added check for geoids and variables that should not have the insignificant css class applied
 - geoids --> `0`, `1`, `2`, `3`, `4`, `5`
 - variables  -->` pop`, `pop_1`,  `pop_2`,  `pop_4`,  `pop_5`,  `pop_6`,  `mdpop3`.


#### Tasks/Bug Numbers
 - Closes #1280 
